### PR TITLE
fix a minor typo in the Markdown code of Travis CI build testing status

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ipfs-unixfs
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
 [[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
-![Build Status](https://travis-ci.org/ipfs/js-ipfs-unixfs.svg?style=flat-square)](https://travis-ci.org/ipfs/js-ipfs-unixfs)
+[![Build Status](https://travis-ci.org/ipfs/js-ipfs-unixfs.svg?style=flat-square)](https://travis-ci.org/ipfs/js-ipfs-unixfs)
 ![](https://img.shields.io/badge/coverage-%3F%25-yellow.svg?style=flat-square)
 [![Dependency Status](https://david-dm.org/ipfs/js-ipfs-unixfs.svg?style=flat-square)](https://david-dm.org/ipfs/js-ipfs-unixfs)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/feross/standard)


### PR DESCRIPTION
This patch fixes the hyperlink that leads to https://travis-ci.org/ipfs/js-ipfs-unixfs

Without this patch https://www.npmjs.com/package/ipfs-unixfs looks slightly wrong.