### PR TITLE
Remove dist folder from npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -24,5 +24,3 @@ build/Release
 
 # Optional REPL history
 .node_repl_history
-
-dist


### PR DESCRIPTION
Fixing issue with #8 as the `dist` directory should also be published to npm. Thanks @dignifiedquire for pointing that out.