### PR TITLE
chore: make mimetype optional as it is in go

### DIFF
--- a/src/unixfs.proto.js
+++ b/src/unixfs.proto.js
@@ -20,5 +20,5 @@ module.exports = `message Data {
 }
 
 message Metadata {
-  required string MimeType = 1;
+  optional string MimeType = 1;
 }`


### PR DESCRIPTION
The mimetype is [optional](https://github.com/ipfs/go-ipfs/blob/master/unixfs/pb/unixfs.proto#L23) in go-ipfs-unixfs so this PR makes it optional in js too.