### PR TITLE
feat: adds metadata to unixfs

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "fs": false
   },
   "scripts": {
-    "test": "aegir test -t node -t browser",
+    "test": "aegir test -t node -t browser -t webworker",
     "test:node": "aegir test -t node",
     "test:browser": "aegir test -t browser",
     "test:webworker": "aegir test -t webworker",
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/ipfs/js-ipfs-unixfs#readme",
   "devDependencies": {
-    "aegir": "^18.0.0",
+    "aegir": "^20.4.1",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "safe-buffer": "^5.1.2"

--- a/src/unixfs.proto.js
+++ b/src/unixfs.proto.js
@@ -14,9 +14,10 @@ module.exports = `message Data {
   optional bytes Data = 2;
   optional uint64 filesize = 3;
   repeated uint64 blocksizes = 4;
-
   optional uint64 hashType = 5;
   optional uint64 fanout = 6;
+  optional uint32 mode = 7;
+  optional int64 mtime = 8;
 }
 
 message Metadata {

--- a/test/unixfs-format.spec.js
+++ b/test/unixfs-format.spec.js
@@ -79,6 +79,48 @@ describe('unixfs-format', () => {
     expect(data.blockSizes).to.not.deep.equal(unmarshalled.blockSizes)
   })
 
+  it('default mode for files', () => {
+    const data = new UnixFS('file')
+    expect(data.mode).to.equal(parseInt('0644', 8))
+    const marshalled = data.marshal()
+    const unmarshalled = UnixFS.unmarshal(marshalled)
+    expect(unmarshalled.mode).to.equal(parseInt('0644', 8))
+  })
+
+  it('default mode for directories', () => {
+    const data = new UnixFS('directory')
+    expect(data.mode).to.equal(parseInt('0755', 8))
+    const marshalled = data.marshal()
+    const unmarshalled = UnixFS.unmarshal(marshalled)
+    expect(unmarshalled.mode).to.equal(parseInt('0755', 8))
+  })
+
+  it('default mode for hamt-sharded-directories', () => {
+    const data = new UnixFS('hamt-sharded-directory')
+    expect(data.mode).to.equal(parseInt('0755', 8))
+    const marshalled = data.marshal()
+    const unmarshalled = UnixFS.unmarshal(marshalled)
+    expect(unmarshalled.mode).to.equal(parseInt('0755', 8))
+  })
+
+  it('mode', () => {
+    const mode = parseInt('0555', 8)
+    const data = new UnixFS('file')
+    data.mode = mode
+    const marshalled = data.marshal()
+    const unmarshalled = UnixFS.unmarshal(marshalled)
+    expect(unmarshalled.mode).to.equal(mode)
+  })
+
+  it('mtime', () => {
+    const mtime = parseInt(Date.now() / 1000)
+    const data = new UnixFS('file')
+    data.mtime = mtime
+    const marshalled = data.marshal()
+    const unmarshalled = UnixFS.unmarshal(marshalled)
+    expect(unmarshalled.mtime).to.equal(mtime)
+  })
+
   // figuring out what is this metadata for https://github.com/ipfs/js-ipfs-data-importing/issues/3#issuecomment-182336526
   it.skip('metadata', () => {})
 


### PR DESCRIPTION
Adds two new fields `mtime` and `mode` in line with the unixfs spec.

One possible wart here is that `mtime` is implemented as a JavaScript number which means it can't hold the full value of `int64` so cannot represent dates in the far future.

This should be addressed by UnixFSv2 which should hopefully arrive before we top out `Number.MAX_SAFE_INTEGER` - e.g. early June 2255.