### PR TITLE
fix: support setting mode to 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "safe-buffer": "^5.1.2"
   },
   "dependencies": {
-    "protons": "^1.0.1"
+    "protons": "ipfs/protons#make-optional-values-optional"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",

--- a/src/index.js
+++ b/src/index.js
@@ -114,19 +114,19 @@ function Data (type, data) {
 }
 
 // decode from protobuf https://github.com/ipfs/go-ipfs/blob/master/unixfs/format.go#L24
-Data.unmarshal = (marsheled) => {
-  const decoded = unixfsData.decode(marsheled)
+Data.unmarshal = (marshaled) => {
+  const decoded = unixfsData.decode(marshaled)
   if (!decoded.Data) {
     decoded.Data = undefined
   }
   const obj = new Data(types[decoded.Type], decoded.Data)
   obj.blockSizes = decoded.blocksizes
 
-  if (decoded.mode) {
+  if (decoded.mode !== null) {
     obj.mode = decoded.mode
   }
 
-  if (decoded.mtime) {
+  if (decoded.mtime !== null) {
     obj.mtime = decoded.mtime
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -122,11 +122,11 @@ Data.unmarshal = (marshaled) => {
   const obj = new Data(types[decoded.Type], decoded.Data)
   obj.blockSizes = decoded.blocksizes
 
-  if (decoded.mode !== null) {
+  if (decoded.mode !== undefined) {
     obj.mode = decoded.mode
   }
 
-  if (decoded.mtime !== null) {
+  if (decoded.mtime !== undefined) {
     obj.mtime = decoded.mtime
   }
 

--- a/test/unixfs-format.spec.js
+++ b/test/unixfs-format.spec.js
@@ -112,6 +112,36 @@ describe('unixfs-format', () => {
     expect(unmarshalled.mode).to.equal(mode)
   })
 
+  it('empty mode', () => {
+    const mode = 0
+    const data = new UnixFS('file')
+    data.mode = mode
+    const marshalled = data.marshal()
+    const unmarshalled = UnixFS.unmarshal(marshalled)
+    expect(unmarshalled.mode).to.equal(mode)
+  })
+
+  it('default file mode', () => {
+    const data = new UnixFS('file')
+    const marshalled = data.marshal()
+    const unmarshalled = UnixFS.unmarshal(marshalled)
+    expect(unmarshalled.mode).to.equal(parseInt('0644', 8))
+  })
+
+  it('default directory mode', () => {
+    const data = new UnixFS('directory')
+    const marshalled = data.marshal()
+    const unmarshalled = UnixFS.unmarshal(marshalled)
+    expect(unmarshalled.mode).to.equal(parseInt('0755', 8))
+  })
+
+  it('default hamt-sharded-directory mode', () => {
+    const data = new UnixFS('directory')
+    const marshalled = data.marshal()
+    const unmarshalled = UnixFS.unmarshal(marshalled)
+    expect(unmarshalled.mode).to.equal(parseInt('0755', 8))
+  })
+
   it('mtime', () => {
     const mtime = parseInt(Date.now() / 1000)
     const data = new UnixFS('file')


### PR DESCRIPTION
The current version of `protons` can't differentiate between a field that was set to 0 or not set at all.  We need this to not have `mode` revert to it's default value when we set it to `0`, which is valid although of little use.

Depends on ipfs/protons#8