### PR TITLE
fix: allow mtime and mode to be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 ![](https://img.shields.io/badge/npm-%3E%3D3.0.0-orange.svg?style=flat-square)
 ![](https://img.shields.io/badge/Node.js-%3E%3D8.0.0-orange.svg?style=flat-square)
 
-> JavaScript implementation of IPFS' unixfs (a Unix FileSystem files representation on top of a MerkleDAG)
+> JavaScript implementation of IPFS' UnixFS (a Unix FileSystem files representation on top of a MerkleDAG)
 
-[The unixfs spec can be found inside the ipfs/specs repository](http://github.com/ipfs/specs)
+The UnixFS spec can be found inside the [ipfs/specs repository](http://github.com/ipfs/specs)
 
 ## Lead Maintainer <!-- omit in toc -->
 
@@ -30,11 +30,12 @@
     - [Create a file composed by several blocks](#create-a-file-composed-by-several-blocks)
     - [Create a directory that contains several files](#create-a-directory-that-contains-several-files)
 - [API](#api)
-    - [unixfs Data Structure](#unixfs-data-structure)
+    - [UnixFS Data Structure](#unixfs-data-structure)
     - [create an unixfs Data element](#create-an-unixfs-data-element)
     - [add and remove a block size to the block size list](#add-and-remove-a-block-size-to-the-block-size-list)
     - [get total fileSize](#get-total-filesize)
     - [marshal and unmarshal](#marshal-and-unmarshal)
+    - [is this UnixFS entry a directory?](#is-this-unixfs-entry-a-directory)
 - [Contribute](#contribute)
 - [License](#license)
 
@@ -49,7 +50,7 @@
 ### Use in Node.js
 
 ```JavaScript
-var Unixfs = require('ipfs-unixfs')
+var UnixFS = require('ipfs-unixfs')
 ```
 
 ### Use in a browser with browserify, webpack or any other bundler
@@ -57,12 +58,12 @@ var Unixfs = require('ipfs-unixfs')
 The code published to npm that gets loaded on require is in fact a ES5 transpiled version with the right shims added. This means that you can require it and use with your favourite bundler without having to adjust asset management process.
 
 ```JavaScript
-var Unixfs = require('ipfs-unixfs')
+var UnixFS = require('ipfs-unixfs')
 ```
 
 ### Use in a browser Using a script tag
 
-Loading this module through a script tag will make the `Unixfs` obj available in the global namespace.
+Loading this module through a script tag will make the `UnixFS` obj available in the global namespace.
 
 ```html
 <script src="https://npmcdn.com/ipfs-unixfs/dist/index.min.js"></script>
@@ -77,7 +78,7 @@ Loading this module through a script tag will make the `Unixfs` obj available in
 #### Create a file composed by several blocks
 
 ```JavaScript
-const data = new Unixfs({ type: 'file' })
+const data = new UnixFS({ type: 'file' })
 data.addBlockSize(256) // add the size of each block
 data.addBlockSize(256)
 // ...
@@ -88,12 +89,12 @@ data.addBlockSize(256)
 Creating a directory that contains several files is achieve by creating a unixfs element that identifies a MerkleDAG node as a directory. The links of that MerkleDAG node are the files that are contained in this directory.
 
 ```JavaScript
-const data = new Unixfs({ type: 'directory' })
+const data = new UnixFS({ type: 'directory' })
 ```
 
 ## API
 
-#### unixfs Data Structure
+#### UnixFS Data Structure
 
 ```protobuf
 syntax = "proto2";
@@ -119,7 +120,7 @@ message Data {
 }
 
 message Metadata {
-  required string MimeType = 1;
+  optional string MimeType = 1;
 }
 ```
 
@@ -131,7 +132,7 @@ const data = new UnixFS([options])
 
 `options` is an optional object argument that might include the following keys:
 
-- type (string, default `file`): The type of UnixFS node.  Can be:
+- type (string, default `file`): The type of UnixFS entry.  Can be:
   - `raw`
   - `directory`
   - `file`
@@ -164,6 +165,16 @@ data.fileSize() // => size in bytes
 ```javascript
 const marshaled = data.marshal()
 const unmarshaled = Unixfs.unmarshal(marshaled)
+```
+
+#### is this UnixFS entry a directory?
+
+```JavaScript
+const dir = new Data({ type: 'directory' })
+dir.isDirectory() // true
+
+const file = new Data({ type: 'file' })
+file.isDirectory() // false
 ```
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ipfs-unixfs JavaScript Implementation
+# ipfs-unixfs JavaScript Implementation <!-- omit in toc -->
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
 [![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io/)
@@ -14,32 +14,29 @@
 
 [The unixfs spec can be found inside the ipfs/specs repository](http://github.com/ipfs/specs)
 
-## Lead Maintainer
+## Lead Maintainer <!-- omit in toc -->
 
 [Alex Potsides](https://github.com/achingbrain)
 
-## Table of Contents
+## Table of Contents <!-- omit in toc -->
 
-- [ipfs-unixfs JavaScript Implementation](#ipfs-unixfs-javascript-implementation)
-  - [Lead Maintainer](#lead-maintainer)
-  - [Table of Contents](#table-of-contents)
-  - [Install](#install)
-    - [npm](#npm)
-    - [Use in Node.js](#use-in-nodejs)
-    - [Use in a browser with browserify, webpack or any other bundler](#use-in-a-browser-with-browserify--webpack-or-any-other-bundler)
-    - [Use in a browser Using a script tag](#use-in-a-browser-using-a-script-tag)
-  - [Usage](#usage)
-    - [Examples](#examples)
-      - [Create a file composed by several blocks](#create-a-file-composed-by-several-blocks)
-      - [Create a directory that contains several files](#create-a-directory-that-contains-several-files)
-  - [API](#api)
-      - [unixfs Data Structure](#unixfs-data-structure)
-      - [create an unixfs Data element](#create-an-unixfs-data-element)
-      - [add and remove a block size to the block size list](#add-and-remove-a-block-size-to-the-block-size-list)
-      - [get total fileSize](#get-total-filesize)
-      - [marshal and unmarshal](#marshal-and-unmarshal)
-  - [Contribute](#contribute)
-  - [License](#license)
+- [Install](#install)
+  - [npm](#npm)
+  - [Use in Node.js](#use-in-nodejs)
+  - [Use in a browser with browserify, webpack or any other bundler](#use-in-a-browser-with-browserify-webpack-or-any-other-bundler)
+  - [Use in a browser Using a script tag](#use-in-a-browser-using-a-script-tag)
+- [Usage](#usage)
+  - [Examples](#examples)
+    - [Create a file composed by several blocks](#create-a-file-composed-by-several-blocks)
+    - [Create a directory that contains several files](#create-a-directory-that-contains-several-files)
+- [API](#api)
+    - [unixfs Data Structure](#unixfs-data-structure)
+    - [create an unixfs Data element](#create-an-unixfs-data-element)
+    - [add and remove a block size to the block size list](#add-and-remove-a-block-size-to-the-block-size-list)
+    - [get total fileSize](#get-total-filesize)
+    - [marshal and unmarshal](#marshal-and-unmarshal)
+- [Contribute](#contribute)
+- [License](#license)
 
 ## Install
 
@@ -80,7 +77,7 @@ Loading this module through a script tag will make the `Unixfs` obj available in
 #### Create a file composed by several blocks
 
 ```JavaScript
-var data = new Unixfs('file')
+const data = new Unixfs({ type: 'file' })
 data.addBlockSize(256) // add the size of each block
 data.addBlockSize(256)
 // ...
@@ -91,7 +88,7 @@ data.addBlockSize(256)
 Creating a directory that contains several files is achieve by creating a unixfs element that identifies a MerkleDAG node as a directory. The links of that MerkleDAG node are the files that are contained in this directory.
 
 ```JavaScript
-var data = new Unixfs('directory')
+const data = new Unixfs({ type: 'directory' })
 ```
 
 ## API
@@ -99,6 +96,8 @@ var data = new Unixfs('directory')
 #### unixfs Data Structure
 
 ```protobuf
+syntax = "proto2";
+
 message Data {
   enum DataType {
     Raw = 0;
@@ -113,23 +112,36 @@ message Data {
   optional bytes Data = 2;
   optional uint64 filesize = 3;
   repeated uint64 blocksizes = 4;
-
   optional uint64 hashType = 5;
   optional uint64 fanout = 6;
+  optional uint32 mode = 7;
+  optional int64 mtime = 8;
 }
 
 message Metadata {
-  optional string MimeType = 1;
+  required string MimeType = 1;
 }
 ```
 
 #### create an unixfs Data element
 
 ```JavaScript
-var data = new UnixFS(<type>, [<content>])
+const data = new UnixFS([options])
 ```
 
-Type can be: `['raw', 'directory', 'file', 'metadata', 'symlink', 'hamt-sharded-directory']`
+`options` is an optional object argument that might include the following keys:
+
+- type (string, default `file`): The type of UnixFS node.  Can be:
+  - `raw`
+  - `directory`
+  - `file`
+  - `metadata`
+  - `symlink`
+  - `hamt-sharded-directory`
+- data (Buffer): The optional data field for this node
+- blockSizes (Array, default: `[]`): If this is a `file` node that is made up of multiple blocks, `blockSizes` is a list numbers that represent the size of the file chunks stored in each child node. It is used to calculate the total file size.
+- mode (Number, default `0644` for files, `0755` for directories/hamt-sharded-directories) file mode
+- mtime (Date, default `0`): The modification time of this node
 
 #### add and remove a block size to the block size list
 
@@ -149,9 +161,9 @@ data.fileSize() // => size in bytes
 
 #### marshal and unmarshal
 
-```
-var marshaled = data.marshal()
-var unmarshaled = Unixfs.unmarshal(marshaled)
+```javascript
+const marshaled = data.marshal()
+const unmarshaled = Unixfs.unmarshal(marshaled)
 ```
 
 ## Contribute

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
   "devDependencies": {
     "aegir": "^20.4.1",
     "chai": "^4.2.0",
-    "dirty-chai": "^2.0.1",
-    "safe-buffer": "^5.1.2"
+    "dirty-chai": "^2.0.1"
   },
   "dependencies": {
     "protons": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "safe-buffer": "^5.1.2"
   },
   "dependencies": {
-    "protons": "^1.0.1"
+    "protons": "^1.1.0"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",

--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ function Data (type, data) {
 
     if (!isNaN(this.mtime)) {
       mtime = {
-        value: this.mtime,
+        seconds: this.mtime,
         hrValue: []
       }
     }
@@ -130,7 +130,7 @@ Data.unmarshal = (marsheled) => {
   }
 
   if (decoded.mtime) {
-    obj.mtime = decoded.mtime.value
+    obj.mtime = decoded.mtime.seconds
   }
 
   return obj

--- a/src/index.js
+++ b/src/index.js
@@ -51,8 +51,8 @@ function Data (type, data) {
     this.blockSizes.forEach((size) => {
       sum += size
     })
-    if (data) {
-      sum += data.length
+    if (this.data) {
+      sum += this.data.length
     }
     return sum
   }
@@ -87,17 +87,13 @@ function Data (type, data) {
     let mode
 
     if (!isNaN(this.mode)) {
-      mode = {
-        value: this.mode
-      }
+      mode = this.mode
     }
 
     let mtime
 
     if (this.mtime) {
-      mtime = {
-        seconds: Math.round(this.mtime.getTime() / 1000)
-      }
+      mtime = Math.round(this.mtime.getTime() / 1000)
     }
 
     return unixfsData.encode({
@@ -116,20 +112,16 @@ function Data (type, data) {
 // decode from protobuf https://github.com/ipfs/go-ipfs/blob/master/unixfs/format.go#L24
 Data.unmarshal = (marshaled) => {
   const decoded = unixfsData.decode(marshaled)
-
-  if (!decoded.Data) {
-    decoded.Data = undefined
-  }
-
-  const obj = new Data(types[decoded.Type], decoded.Data)
+  const data = decoded.hasData() ? decoded.Data : undefined
+  const obj = new Data(types[decoded.Type], data)
   obj.blockSizes = decoded.blocksizes
 
-  if (decoded.mode) {
-    obj.mode = decoded.mode.value
+  if (decoded.hasMode()) {
+    obj.mode = decoded.mode
   }
 
-  if (decoded.mtime) {
-    obj.mtime = new Date(decoded.mtime.seconds * 1000)
+  if (decoded.hasMtime()) {
+    obj.mtime = new Date(decoded.mtime * 1000)
   }
 
   return obj

--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,7 @@ class Data {
         mode = undefined
       }
 
-      if (mode === DEFAULT_DIRECTORY_MODE && this.type.includes('directory')) {
+      if (mode === DEFAULT_DIRECTORY_MODE && this.isDirectory()) {
         mode = undefined
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ function Data (type, data) {
 
     let mode
 
-    if (this.mode != null && this.mode >= 0) {
+    if (!isNaN(this.mode)) {
       mode = {
         value: this.mode
       }
@@ -94,11 +94,10 @@ function Data (type, data) {
 
     let mtime
 
-    if (this.mtime != null && this.mtime >= 0) {
+    if (!isNaN(this.mtime)) {
       mtime = {
-        value: [
-          this.mtime
-        ]
+        value: this.mtime,
+        hrValue: []
       }
     }
 
@@ -126,12 +125,12 @@ Data.unmarshal = (marsheled) => {
   const obj = new Data(types[decoded.Type], decoded.Data)
   obj.blockSizes = decoded.blocksizes
 
-  if (decoded.mode != null) {
+  if (decoded.mode) {
     obj.mode = decoded.mode.value
   }
 
-  if (decoded.mtime != null) {
-    obj.mtime = decoded.mtime.value[0]
+  if (decoded.mtime) {
+    obj.mtime = decoded.mtime.value
   }
 
   return obj

--- a/src/index.js
+++ b/src/index.js
@@ -94,10 +94,9 @@ function Data (type, data) {
 
     let mtime
 
-    if (!isNaN(this.mtime)) {
+    if (this.mtime) {
       mtime = {
-        seconds: this.mtime,
-        hrValue: []
+        seconds: Math.round(this.mtime.getTime() / 1000)
       }
     }
 
@@ -115,8 +114,8 @@ function Data (type, data) {
 }
 
 // decode from protobuf https://github.com/ipfs/go-ipfs/blob/master/unixfs/format.go#L24
-Data.unmarshal = (marsheled) => {
-  const decoded = unixfsData.decode(marsheled)
+Data.unmarshal = (marshaled) => {
+  const decoded = unixfsData.decode(marshaled)
 
   if (!decoded.Data) {
     decoded.Data = undefined
@@ -130,7 +129,7 @@ Data.unmarshal = (marsheled) => {
   }
 
   if (decoded.mtime) {
-    obj.mtime = decoded.mtime.seconds
+    obj.mtime = new Date(decoded.mtime.seconds * 1000)
   }
 
   return obj

--- a/src/unixfs.proto.js
+++ b/src/unixfs.proto.js
@@ -21,13 +21,13 @@ module.exports = `message Data {
 }
 
 message Metadata {
-  optional string MimeType = 1;
+  required string MimeType = 1;
 }
 
 message Mode {
-  optional uint32 value = 1;
+  required uint32 value = 1;
 }
 
 message Mtime {
-  repeated int64 value = 1;
+  required int64 value = 1;
 }`

--- a/src/unixfs.proto.js
+++ b/src/unixfs.proto.js
@@ -24,6 +24,6 @@ message Data {
 }
 
 message Metadata {
-  required string MimeType = 1;
+  optional string MimeType = 1;
 }
 `

--- a/src/unixfs.proto.js
+++ b/src/unixfs.proto.js
@@ -1,6 +1,9 @@
 'use strict'
 
-module.exports = `message Data {
+module.exports = `
+syntax = "proto2";
+
+message Data {
   enum DataType {
     Raw = 0;
     Directory = 1;
@@ -16,18 +19,11 @@ module.exports = `message Data {
   repeated uint64 blocksizes = 4;
   optional uint64 hashType = 5;
   optional uint64 fanout = 6;
-  optional Mode mode = 7;
-  optional Mtime mtime = 8;
+  optional uint32 mode = 7;
+  optional int64 mtime = 8;
 }
 
 message Metadata {
   required string MimeType = 1;
 }
-
-message Mode {
-  required uint32 value = 1;
-}
-
-message Mtime {
-  required int64 seconds = 1;
-}`
+`

--- a/src/unixfs.proto.js
+++ b/src/unixfs.proto.js
@@ -29,6 +29,6 @@ message Mode {
 }
 
 message Mtime {
-  required int64 value = 1;
+  required int64 seconds = 1;
   repeated int64 hrValue = 2;
 }`

--- a/src/unixfs.proto.js
+++ b/src/unixfs.proto.js
@@ -16,10 +16,18 @@ module.exports = `message Data {
   repeated uint64 blocksizes = 4;
   optional uint64 hashType = 5;
   optional uint64 fanout = 6;
-  optional uint32 mode = 7;
-  optional int64 mtime = 8;
+  optional Mode mode = 7;
+  optional Mtime mtime = 8;
 }
 
 message Metadata {
   optional string MimeType = 1;
+}
+
+message Mode {
+  optional uint32 value = 1;
+}
+
+message Mtime {
+  repeated int64 value = 1;
 }`

--- a/src/unixfs.proto.js
+++ b/src/unixfs.proto.js
@@ -30,5 +30,5 @@ message Mode {
 
 message Mtime {
   required int64 value = 1;
-  repeated int64 hrValue = 1;
+  repeated int64 hrValue = 2;
 }`

--- a/src/unixfs.proto.js
+++ b/src/unixfs.proto.js
@@ -30,5 +30,4 @@ message Mode {
 
 message Mtime {
   required int64 seconds = 1;
-  repeated int64 hrValue = 2;
 }`

--- a/src/unixfs.proto.js
+++ b/src/unixfs.proto.js
@@ -30,4 +30,5 @@ message Mode {
 
 message Mtime {
   required int64 value = 1;
+  repeated int64 hrValue = 1;
 }`

--- a/test/unixfs-format.spec.js
+++ b/test/unixfs-format.spec.js
@@ -79,37 +79,33 @@ describe('unixfs-format', () => {
     expect(data.blockSizes).to.not.deep.equal(unmarshalled.blockSizes)
   })
 
-  it('default mode for files', () => {
-    const data = new UnixFS('file')
-    expect(data.mode).to.equal(parseInt('0644', 8))
-    const marshalled = data.marshal()
-    const unmarshalled = UnixFS.unmarshal(marshalled)
-    expect(unmarshalled.mode).to.equal(parseInt('0644', 8))
-  })
-
-  it('default mode for directories', () => {
-    const data = new UnixFS('directory')
-    expect(data.mode).to.equal(parseInt('0755', 8))
-    const marshalled = data.marshal()
-    const unmarshalled = UnixFS.unmarshal(marshalled)
-    expect(unmarshalled.mode).to.equal(parseInt('0755', 8))
-  })
-
-  it('default mode for hamt-sharded-directories', () => {
-    const data = new UnixFS('hamt-sharded-directory')
-    expect(data.mode).to.equal(parseInt('0755', 8))
-    const marshalled = data.marshal()
-    const unmarshalled = UnixFS.unmarshal(marshalled)
-    expect(unmarshalled.mode).to.equal(parseInt('0755', 8))
-  })
-
   it('mode', () => {
     const mode = parseInt('0555', 8)
     const data = new UnixFS('file')
     data.mode = mode
-    const marshalled = data.marshal()
-    const unmarshalled = UnixFS.unmarshal(marshalled)
-    expect(unmarshalled.mode).to.equal(mode)
+
+    expect(UnixFS.unmarshal(data.marshal())).to.have.property('mode', mode)
+  })
+
+  it('removes mode', () => {
+    const mode = parseInt('0555', 8)
+    const data = new UnixFS('file')
+    data.mode = mode
+
+    const unmarshalled = UnixFS.unmarshal(data.marshal())
+    expect(unmarshalled).to.have.property('mode', mode)
+
+    delete unmarshalled.mode
+
+    expect(UnixFS.unmarshal(unmarshalled.marshal())).to.not.have.property('mode')
+  })
+
+  it('sets mode to 0', () => {
+    const mode = 0
+    const data = new UnixFS('file')
+    data.mode = mode
+
+    expect(UnixFS.unmarshal(data.marshal())).to.have.property('mode', mode)
   })
 
   it('mtime', () => {
@@ -119,6 +115,27 @@ describe('unixfs-format', () => {
     const marshalled = data.marshal()
     const unmarshalled = UnixFS.unmarshal(marshalled)
     expect(unmarshalled.mtime).to.equal(mtime)
+  })
+
+  it('removes mtime', () => {
+    const mtime = parseInt(Date.now() / 1000)
+    const data = new UnixFS('file')
+    data.mtime = mtime
+
+    const unmarshalled = UnixFS.unmarshal(data.marshal())
+    expect(unmarshalled).to.have.property('mtime', mtime)
+
+    delete unmarshalled.mtime
+
+    expect(UnixFS.unmarshal(unmarshalled.marshal())).to.not.have.property('mtime')
+  })
+
+  it('sets mtime to 0', () => {
+    const mtime = 0
+    const data = new UnixFS('file')
+    data.mtime = mtime
+
+    expect(UnixFS.unmarshal(data.marshal())).to.have.property('mtime', mtime)
   })
 
   // figuring out what is this metadata for https://github.com/ipfs/js-ipfs-data-importing/issues/3#issuecomment-182336526

--- a/test/unixfs-format.spec.js
+++ b/test/unixfs-format.spec.js
@@ -17,66 +17,66 @@ const Buffer = require('safe-buffer').Buffer
 describe('unixfs-format', () => {
   it('raw', () => {
     const data = new UnixFS('raw', Buffer.from('bananas'))
-    const marshalled = data.marshal()
-    const unmarshalled = UnixFS.unmarshal(marshalled)
-    expect(data.type).to.equal(unmarshalled.type)
-    expect(data.data).to.deep.equal(unmarshalled.data)
-    expect(data.blockSizes).to.deep.equal(unmarshalled.blockSizes)
-    expect(data.fileSize()).to.deep.equal(unmarshalled.fileSize())
+    const marshaled = data.marshal()
+    const unmarshaled = UnixFS.unmarshal(marshaled)
+    expect(data.type).to.equal(unmarshaled.type)
+    expect(data.data).to.deep.equal(unmarshaled.data)
+    expect(data.blockSizes).to.deep.equal(unmarshaled.blockSizes)
+    expect(data.fileSize()).to.deep.equal(unmarshaled.fileSize())
   })
 
   it('directory', () => {
     const data = new UnixFS('directory')
-    const marshalled = data.marshal()
-    const unmarshalled = UnixFS.unmarshal(marshalled)
-    expect(data.type).to.equal(unmarshalled.type)
-    expect(data.data).to.deep.equal(unmarshalled.data)
-    expect(data.blockSizes).to.deep.equal(unmarshalled.blockSizes)
-    expect(data.fileSize()).to.deep.equal(unmarshalled.fileSize())
+    const marshaled = data.marshal()
+    const unmarshaled = UnixFS.unmarshal(marshaled)
+    expect(data.type).to.equal(unmarshaled.type)
+    expect(data.data).to.deep.equal(unmarshaled.data)
+    expect(data.blockSizes).to.deep.equal(unmarshaled.blockSizes)
+    expect(data.fileSize()).to.deep.equal(unmarshaled.fileSize())
   })
 
   it('hamt-sharded-directory', () => {
     const data = new UnixFS('hamt-sharded-directory')
-    const marshalled = data.marshal()
-    const unmarshalled = UnixFS.unmarshal(marshalled)
-    expect(data.type).to.equal(unmarshalled.type)
-    expect(data.data).to.deep.equal(unmarshalled.data)
-    expect(data.blockSizes).to.deep.equal(unmarshalled.blockSizes)
-    expect(data.fileSize()).to.deep.equal(unmarshalled.fileSize())
+    const marshaled = data.marshal()
+    const unmarshaled = UnixFS.unmarshal(marshaled)
+    expect(data.type).to.equal(unmarshaled.type)
+    expect(data.data).to.deep.equal(unmarshaled.data)
+    expect(data.blockSizes).to.deep.equal(unmarshaled.blockSizes)
+    expect(data.fileSize()).to.deep.equal(unmarshaled.fileSize())
   })
 
   it('file', () => {
     const data = new UnixFS('file', Buffer.from('batata'))
-    const marshalled = data.marshal()
-    const unmarshalled = UnixFS.unmarshal(marshalled)
-    expect(data.type).to.equal(unmarshalled.type)
-    expect(data.data).to.deep.equal(unmarshalled.data)
-    expect(data.blockSizes).to.deep.equal(unmarshalled.blockSizes)
-    expect(data.fileSize()).to.deep.equal(unmarshalled.fileSize())
+    const marshaled = data.marshal()
+    const unmarshaled = UnixFS.unmarshal(marshaled)
+    expect(data.type).to.equal(unmarshaled.type)
+    expect(data.data).to.deep.equal(unmarshaled.data)
+    expect(data.blockSizes).to.deep.equal(unmarshaled.blockSizes)
+    expect(data.fileSize()).to.deep.equal(unmarshaled.fileSize())
   })
 
   it('file add blocksize', () => {
     const data = new UnixFS('file')
     data.addBlockSize(256)
-    const marshalled = data.marshal()
-    const unmarshalled = UnixFS.unmarshal(marshalled)
-    expect(data.type).to.equal(unmarshalled.type)
-    expect(data.data).to.deep.equal(unmarshalled.data)
-    expect(data.blockSizes).to.deep.equal(unmarshalled.blockSizes)
-    expect(data.fileSize()).to.deep.equal(unmarshalled.fileSize())
+    const marshaled = data.marshal()
+    const unmarshaled = UnixFS.unmarshal(marshaled)
+    expect(data.type).to.equal(unmarshaled.type)
+    expect(data.data).to.deep.equal(unmarshaled.data)
+    expect(data.blockSizes).to.deep.equal(unmarshaled.blockSizes)
+    expect(data.fileSize()).to.deep.equal(unmarshaled.fileSize())
   })
 
   it('file add and remove blocksize', () => {
     const data = new UnixFS('file')
     data.addBlockSize(256)
-    const marshalled = data.marshal()
-    const unmarshalled = UnixFS.unmarshal(marshalled)
-    expect(data.type).to.equal(unmarshalled.type)
-    expect(data.data).to.deep.equal(unmarshalled.data)
-    expect(data.blockSizes).to.deep.equal(unmarshalled.blockSizes)
-    expect(data.fileSize()).to.deep.equal(unmarshalled.fileSize())
-    unmarshalled.removeBlockSize(0)
-    expect(data.blockSizes).to.not.deep.equal(unmarshalled.blockSizes)
+    const marshaled = data.marshal()
+    const unmarshaled = UnixFS.unmarshal(marshaled)
+    expect(data.type).to.equal(unmarshaled.type)
+    expect(data.data).to.deep.equal(unmarshaled.data)
+    expect(data.blockSizes).to.deep.equal(unmarshaled.blockSizes)
+    expect(data.fileSize()).to.deep.equal(unmarshaled.fileSize())
+    unmarshaled.removeBlockSize(0)
+    expect(data.blockSizes).to.not.deep.equal(unmarshaled.blockSizes)
   })
 
   it('mode', () => {
@@ -92,12 +92,12 @@ describe('unixfs-format', () => {
     const data = new UnixFS('file')
     data.mode = mode
 
-    const unmarshalled = UnixFS.unmarshal(data.marshal())
-    expect(unmarshalled).to.have.property('mode', mode)
+    const unmarshaled = UnixFS.unmarshal(data.marshal())
+    expect(unmarshaled).to.have.property('mode', mode)
 
-    delete unmarshalled.mode
+    delete unmarshaled.mode
 
-    expect(UnixFS.unmarshal(unmarshalled.marshal())).to.not.have.property('mode')
+    expect(UnixFS.unmarshal(unmarshaled.marshal())).to.not.have.property('mode')
   })
 
   it('sets mode to 0', () => {
@@ -109,33 +109,33 @@ describe('unixfs-format', () => {
   })
 
   it('mtime', () => {
-    const mtime = parseInt(Date.now() / 1000)
+    const mtime = new Date()
     const data = new UnixFS('file')
     data.mtime = mtime
-    const marshalled = data.marshal()
-    const unmarshalled = UnixFS.unmarshal(marshalled)
-    expect(unmarshalled.mtime).to.equal(mtime)
+    const marshaled = data.marshal()
+    const unmarshaled = UnixFS.unmarshal(marshaled)
+    expect(unmarshaled.mtime).to.deep.equal(new Date(Math.round(mtime.getTime() / 1000) * 1000))
   })
 
   it('removes mtime', () => {
-    const mtime = parseInt(Date.now() / 1000)
+    const mtime = new Date()
     const data = new UnixFS('file')
     data.mtime = mtime
 
-    const unmarshalled = UnixFS.unmarshal(data.marshal())
-    expect(unmarshalled).to.have.property('mtime', mtime)
+    const unmarshaled = UnixFS.unmarshal(data.marshal())
+    expect(unmarshaled).to.have.deep.property('mtime', new Date(Math.round(mtime.getTime() / 1000) * 1000))
 
-    delete unmarshalled.mtime
+    delete unmarshaled.mtime
 
-    expect(UnixFS.unmarshal(unmarshalled.marshal())).to.not.have.property('mtime')
+    expect(UnixFS.unmarshal(unmarshaled.marshal())).to.not.have.property('mtime')
   })
 
   it('sets mtime to 0', () => {
-    const mtime = 0
+    const mtime = new Date(0)
     const data = new UnixFS('file')
     data.mtime = mtime
 
-    expect(UnixFS.unmarshal(data.marshal())).to.have.property('mtime', mtime)
+    expect(UnixFS.unmarshal(data.marshal())).to.have.deep.property('mtime', new Date(Math.round(mtime.getTime() / 1000) * 1000))
   })
 
   // figuring out what is this metadata for https://github.com/ipfs/js-ipfs-data-importing/issues/3#issuecomment-182336526
@@ -143,12 +143,12 @@ describe('unixfs-format', () => {
 
   it('symlink', () => {
     const data = new UnixFS('symlink')
-    const marshalled = data.marshal()
-    const unmarshalled = UnixFS.unmarshal(marshalled)
-    expect(data.type).to.equal(unmarshalled.type)
-    expect(data.data).to.deep.equal(unmarshalled.data)
-    expect(data.blockSizes).to.deep.equal(unmarshalled.blockSizes)
-    expect(data.fileSize()).to.deep.equal(unmarshalled.fileSize())
+    const marshaled = data.marshal()
+    const unmarshaled = UnixFS.unmarshal(marshaled)
+    expect(data.type).to.equal(unmarshaled.type)
+    expect(data.data).to.deep.equal(unmarshaled.data)
+    expect(data.blockSizes).to.deep.equal(unmarshaled.blockSizes)
+    expect(data.fileSize()).to.deep.equal(unmarshaled.fileSize())
   })
   it('wrong type', (done) => {
     let data
@@ -163,42 +163,42 @@ describe('unixfs-format', () => {
 
   describe('interop', () => {
     it('raw', () => {
-      const unmarshalled = UnixFS.unmarshal(raw)
-      expect(unmarshalled.data).to.eql(Buffer.from('Hello UnixFS\n'))
-      expect(unmarshalled.type).to.equal('file')
-      expect(unmarshalled.marshal()).to.deep.equal(raw)
+      const unmarshaled = UnixFS.unmarshal(raw)
+      expect(unmarshaled.data).to.eql(Buffer.from('Hello UnixFS\n'))
+      expect(unmarshaled.type).to.equal('file')
+      expect(unmarshaled.marshal()).to.deep.equal(raw)
     })
 
     it('directory', () => {
-      const unmarshalled = UnixFS.unmarshal(directory)
-      expect(unmarshalled.data).to.deep.equal(undefined)
-      expect(unmarshalled.type).to.equal('directory')
-      expect(unmarshalled.marshal()).to.deep.equal(directory)
+      const unmarshaled = UnixFS.unmarshal(directory)
+      expect(unmarshaled.data).to.deep.equal(undefined)
+      expect(unmarshaled.type).to.equal('directory')
+      expect(unmarshaled.marshal()).to.deep.equal(directory)
     })
 
     it('file', () => {
-      const unmarshalled = UnixFS.unmarshal(file)
-      expect(unmarshalled.data).to.deep.equal(Buffer.from('Hello UnixFS\n'))
-      expect(unmarshalled.type).to.equal('file')
-      expect(unmarshalled.marshal()).to.deep.equal(file)
+      const unmarshaled = UnixFS.unmarshal(file)
+      expect(unmarshaled.data).to.deep.equal(Buffer.from('Hello UnixFS\n'))
+      expect(unmarshaled.type).to.equal('file')
+      expect(unmarshaled.marshal()).to.deep.equal(file)
     })
 
     it.skip('metadata', () => {
     })
 
     it('symlink', () => {
-      const unmarshalled = UnixFS.unmarshal(symlink)
-      expect(unmarshalled.data).to.deep.equal(Buffer.from('file.txt'))
-      expect(unmarshalled.type).to.equal('symlink')
+      const unmarshaled = UnixFS.unmarshal(symlink)
+      expect(unmarshaled.data).to.deep.equal(Buffer.from('file.txt'))
+      expect(unmarshaled.type).to.equal('symlink')
       // TODO: waiting on https://github.com/ipfs/js-ipfs-data-importing/issues/3#issuecomment-182440079
-      // expect(unmarshalled.marshal()).to.deep.equal(symlink)
+      // expect(unmarshaled.marshal()).to.deep.equal(symlink)
     })
   })
 
   it('empty', () => {
     const data = new UnixFS('file')
-    const marshalled = data.marshal()
+    const marshaled = data.marshal()
 
-    expect(marshalled).to.deep.equal(Buffer.from([0x08, 0x02, 0x18, 0x00]))
+    expect(marshaled).to.deep.equal(Buffer.from([0x08, 0x02, 0x18, 0x00]))
   })
 })

--- a/test/unixfs-format.spec.js
+++ b/test/unixfs-format.spec.js
@@ -12,7 +12,7 @@ const raw = loadFixture('test/fixtures/raw.unixfs')
 const directory = loadFixture('test/fixtures/directory.unixfs')
 const file = loadFixture('test/fixtures/file.txt.unixfs')
 const symlink = loadFixture('test/fixtures/symlink.txt.unixfs')
-const Buffer = require('safe-buffer').Buffer
+const { Buffer } = require('buffer')
 
 describe('unixfs-format', () => {
   it('defaults to file', () => {


### PR DESCRIPTION
Upgrades `protons` to take advantage of new `hasFoo` type methods to detect if the user has set `mode` and `mtime` or not.

Also updates the constructor:

```javascript
// old
new UnixFS('file', buf)

// new
new UnixFS('file', buf) // still supported
new UnixFS() // defaults to 'file' without data
new UnixFS({ // all fields are optional, apart from `type`
  type: 'file',
  data: buf,
  blockSizes: [],
  mode: parseInt('0755', 8),
  mtime: new Date()
})
```

This is to not have the [boolean-trap](https://ariya.io/2011/08/hall-of-api-shame-boolean-trap) style constructor of:

```javascript
new UnixFS(type, data, bufferSizes, mode, mtime)
```
