### PR TITLE
refactor: use the block API from ipfs instead of ipld internals

### DIFF
--- a/packages/ipfs-unixfs-exporter/test/exporter-sharded.spec.js
+++ b/packages/ipfs-unixfs-exporter/test/exporter-sharded.spec.js
@@ -18,6 +18,7 @@ const {
   DAGLink,
   DAGNode
 } = require('ipld-dag-pb')
+const blockApi = require('./helpers/block')
 
 const SHARD_SPLIT_THRESHOLD = 10
 
@@ -25,6 +26,7 @@ describe('exporter sharded', function () {
   this.timeout(30000)
 
   let ipld
+  let block
 
   const createShard = (numFiles) => {
     return createShardWithFileNames(numFiles, (index) => `file-${index}`)
@@ -40,7 +42,7 @@ describe('exporter sharded', function () {
   }
 
   const createShardWithFiles = async (files) => {
-    return (await last(importer(files, ipld, {
+    return (await last(importer(files, block, {
       shardSplitThreshold: SHARD_SPLIT_THRESHOLD,
       wrapWithDirectory: true
     }))).cid
@@ -48,6 +50,7 @@ describe('exporter sharded', function () {
 
   before(async () => {
     ipld = await inMemory(IPLD)
+    block = blockApi(ipld)
   })
 
   it('exports a sharded directory', async () => {
@@ -62,7 +65,7 @@ describe('exporter sharded', function () {
     const imported = await all(importer(Object.keys(files).map(path => ({
       path,
       content: files[path].content
-    })), ipld, {
+    })), block, {
       wrapWithDirectory: true,
       shardSplitThreshold: SHARD_SPLIT_THRESHOLD
     }))

--- a/packages/ipfs-unixfs-exporter/test/exporter-subtree.spec.js
+++ b/packages/ipfs-unixfs-exporter/test/exporter-subtree.spec.js
@@ -11,6 +11,7 @@ const mc = require('multicodec')
 const all = require('async-iterator-all')
 const last = require('it-last')
 const randomBytes = require('async-iterator-buffer-stream')
+const blockApi = require('./helpers/block')
 
 const ONE_MEG = Math.pow(1024, 2)
 
@@ -18,9 +19,11 @@ const exporter = require('./../src')
 
 describe('exporter subtree', () => {
   let ipld
+  let block
 
   before(async () => {
     ipld = await inMemory(IPLD)
+    block = blockApi(ipld)
   })
 
   it('exports a file 2 levels down', async () => {
@@ -32,7 +35,7 @@ describe('exporter subtree', () => {
     }, {
       path: './level-1/200Bytes.txt',
       content
-    }], ipld))
+    }], block))
 
     const exported = await exporter(`${imported.cid.toBaseEncodedString()}/level-1/200Bytes.txt`, ipld)
 
@@ -54,7 +57,7 @@ describe('exporter subtree', () => {
       content
     }, {
       path: './level-1/level-2'
-    }], ipld))
+    }], block))
 
     const exported = await exporter(`${imported.cid.toBaseEncodedString()}/level-1`, ipld)
     const files = await all(exported.content())
@@ -74,7 +77,7 @@ describe('exporter subtree', () => {
     const imported = await last(importer([{
       path: '/derp/200Bytes.txt',
       content: randomBytes(ONE_MEG)
-    }], ipld))
+    }], block))
 
     try {
       await exporter(`${imported.cid.toBaseEncodedString()}/doesnotexist`, ipld)
@@ -89,7 +92,7 @@ describe('exporter subtree', () => {
     const imported = await last(importer([{
       path: './level-1/200Bytes.txt',
       content
-    }], ipld, {
+    }], block, {
       wrapWithDirectory: true
     }))
 
@@ -122,7 +125,7 @@ describe('exporter subtree', () => {
     }, {
       path: './level-1/level-2/200Bytes.txt',
       content
-    }], ipld))
+    }], block))
 
     const exported = await all(exporter.path(`${imported.cid.toBaseEncodedString()}/level-1/level-2/200Bytes.txt`, ipld))
 

--- a/packages/ipfs-unixfs-exporter/test/exporter.spec.js
+++ b/packages/ipfs-unixfs-exporter/test/exporter.spec.js
@@ -22,11 +22,13 @@ const last = require('it-last')
 const first = require('async-iterator-first')
 const randomBytes = require('async-iterator-buffer-stream')
 const AbortController = require('abort-controller')
+const blockApi = require('./helpers/block')
 
 const ONE_MEG = Math.pow(1024, 2)
 
 describe('exporter', () => {
   let ipld
+  let block
   let bigFile
   let smallFile
 
@@ -58,7 +60,7 @@ describe('exporter', () => {
     const result = await all(importer([{
       path,
       content: file
-    }], ipld, {
+    }], block, {
       strategy,
       rawLeaves,
       chunkerOptions: {
@@ -123,6 +125,7 @@ describe('exporter', () => {
 
   before(async () => {
     ipld = await inMemory(IPLD)
+    block = blockApi(ipld)
   })
 
   it('ensure hash inputs are sanitized', async () => {
@@ -148,7 +151,7 @@ describe('exporter', () => {
     const files = await all(importer([{
       path: filePath,
       content: smallFile
-    }], ipld))
+    }], block))
 
     const path = `/ipfs/${files[1].cid.toBaseEncodedString()}/${fileName}`
     const file = await exporter(path, ipld)
@@ -164,7 +167,7 @@ describe('exporter', () => {
     const files = await all(importer([{
       path: filePath,
       content: smallFile
-    }], ipld))
+    }], block))
 
     const path = `/ipfs/${files[1].cid.toBaseEncodedString()}/${fileName}`
     const file = await exporter(path, ipld)
@@ -333,7 +336,7 @@ describe('exporter', () => {
       content: randomBytes(ONE_MEG)
     }, {
       path: './level-1/level-2'
-    }], ipld))
+    }], block))
     const dir = await exporter(importedDir.cid, ipld)
     const files = await all(dir.content())
 
@@ -371,7 +374,7 @@ describe('exporter', () => {
       path: './dir-another'
     }, {
       path: './level-1'
-    }], ipld))
+    }], block))
 
     const dir = await exporter(importedDir.cid, ipld)
     const files = await all(dir.content())
@@ -516,7 +519,7 @@ describe('exporter', () => {
     const imported = await first(importer([{
       path: '1.2MiB.txt',
       content: bigFile
-    }], ipld, {
+    }], block, {
       rawLeaves: true
     }))
 
@@ -529,7 +532,7 @@ describe('exporter', () => {
   it('returns an empty stream for dir', async () => {
     const imported = await first(importer([{
       path: 'empty'
-    }], ipld))
+    }], block))
     const dir = await exporter(imported.cid, ipld)
     const files = await all(dir.content())
     expect(files.length).to.equal(0)
@@ -755,7 +758,7 @@ describe('exporter', () => {
     const imported = await first(importer([{
       path: '200Bytes.txt',
       content: bigFile
-    }], ipld, {
+    }], block, {
       rawLeaves: true
     }))
 
@@ -771,7 +774,7 @@ describe('exporter', () => {
     const imported = await first(importer([{
       path: '200Bytes.txt',
       content: smallFile
-    }], ipld, {
+    }], block, {
       rawLeaves: true
     }))
 
@@ -862,7 +865,7 @@ describe('exporter', () => {
     const imported = await all(importer([{
       path: '/foo/bar/baz.txt',
       content: Buffer.from('hello world')
-    }], ipld))
+    }], block))
 
     const exported = await exporter(imported[0].cid, ipld)
 
@@ -879,7 +882,7 @@ describe('exporter', () => {
     }, {
       path: '/foo/bar/quux.txt',
       content: Buffer.from('hello world')
-    }], ipld))
+    }], block))
 
     const exported = await all(exporter.recursive(dir.cid, ipld))
     const dirCid = dir.cid.toBaseEncodedString()

--- a/packages/ipfs-unixfs-exporter/test/helpers/block.js
+++ b/packages/ipfs-unixfs-exporter/test/helpers/block.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const DAG_PB = require('ipld-dag-pb')
+const multicodec = require('multicodec')
+const mh = require('multihashing-async').multihash
+
+module.exports = (ipld) => {
+  // make ipld behave like the block api, some tests need to pull
+  // data from ipld so can't use use a simple hash
+  return {
+    put: async (buf, { cid }) => {
+      const multihash = mh.decode(cid.multihash)
+
+      if (cid.codec === 'dag-pb') {
+        buf = DAG_PB.util.deserialize(buf)
+      }
+
+      await ipld.put(buf, cid.codec === 'dag-pb' ? multicodec.DAG_PB : multicodec.RAW, {
+        cidVersion: cid.version,
+        hashAlg: multihash.code
+      })
+
+      return { cid, data: buf }
+    },
+    get: async (cid, options) => {
+      const node = await ipld.get(cid, options)
+
+      if (cid.codec === 'dag-pb') {
+        return node.serialize()
+      }
+
+      return { cid, data: node }
+    }
+  }
+}

--- a/packages/ipfs-unixfs-importer/README.md
+++ b/packages/ipfs-unixfs-importer/README.md
@@ -140,6 +140,8 @@ The input's file paths and directory structure will be preserved in the [`dag-pb
 - `leafType` (string, defaults to `'file'`) what type of UnixFS node leaves should be - can be `'file'` or `'raw'` (ignored when `rawLeaves` is `true`)
 - `blockWriteConcurrency` (positive integer, defaults to 10) How many blocks to hash and write to the block store concurrently. For small numbers of large files this should be high (e.g. 50).
 - `fileImportConcurrency` (number, defaults to 50) How many files to import concurrently. For large numbers of small files this should be high (e.g. 50).
+- `pin` (boolean, defaults to `false`) Whether to pin each block as it is created
+- `preload` (boolean, defaults to `false`) Whether to preload each block as it is created
 
 ## Overriding internals
 

--- a/packages/ipfs-unixfs-importer/package.json
+++ b/packages/ipfs-unixfs-importer/package.json
@@ -46,6 +46,7 @@
     "ipld-in-memory": "^3.0.0",
     "it-buffer-stream": "^1.0.0",
     "it-last": "^1.0.1",
+    "multicodec": "^1.0.0",
     "nyc": "^15.0.0",
     "sinon": "^9.0.1"
   },
@@ -60,7 +61,6 @@
     "it-first": "^1.0.1",
     "it-parallel-batch": "^1.0.3",
     "merge-options": "^2.0.0",
-    "multicodec": "^1.0.0",
     "multihashing-async": "^0.8.0",
     "rabin-wasm": "^0.1.1"
   }

--- a/packages/ipfs-unixfs-importer/src/dag-builder/dir.js
+++ b/packages/ipfs-unixfs-importer/src/dag-builder/dir.js
@@ -6,22 +6,22 @@ const {
   DAGNode
 } = require('ipld-dag-pb')
 
-const dirBuilder = async (item, ipld, options) => {
+const dirBuilder = async (item, block, options) => {
   const unixfs = new UnixFS({
     type: 'directory',
     mtime: item.mtime,
     mode: item.mode
   })
 
-  const node = new DAGNode(unixfs.marshal(), [])
-  const cid = await persist(node, ipld, options)
+  const buffer = new DAGNode(unixfs.marshal()).serialize()
+  const cid = await persist(buffer, block, options)
   const path = item.path
 
   return {
     cid,
     path,
     unixfs,
-    size: node.size
+    size: buffer.length
   }
 }
 

--- a/packages/ipfs-unixfs-importer/src/dag-builder/index.js
+++ b/packages/ipfs-unixfs-importer/src/dag-builder/index.js
@@ -3,7 +3,7 @@
 const dirBuilder = require('./dir')
 const fileBuilder = require('./file')
 
-async function * dagBuilder (source, ipld, options) {
+async function * dagBuilder (source, block, options) {
   for await (const entry of source) {
     if (entry.path) {
       if (entry.path.substring(0, 2) === './') {
@@ -47,10 +47,10 @@ async function * dagBuilder (source, ipld, options) {
       }
 
       // item is a file
-      yield () => fileBuilder(entry, chunker(chunkValidator(source, options), options), ipld, options)
+      yield () => fileBuilder(entry, chunker(chunkValidator(source, options), options), block, options)
     } else {
       // item is a directory
-      yield () => dirBuilder(entry, ipld, options)
+      yield () => dirBuilder(entry, block, options)
     }
   }
 }

--- a/packages/ipfs-unixfs-importer/src/index.js
+++ b/packages/ipfs-unixfs-importer/src/index.js
@@ -25,15 +25,15 @@ const defaultOptions = {
   maxChildrenPerNode: 174,
   layerRepeat: 4,
   wrapWithDirectory: false,
-  pin: true,
+  pin: false,
   recursive: false,
   hidden: false,
-  preload: true,
+  preload: false,
   chunkValidator: null,
   importBuffer: null
 }
 
-module.exports = async function * (source, ipld, options = {}) {
+module.exports = async function * (source, block, options = {}) {
   const opts = mergeOptions(defaultOptions, options)
 
   if (options.cidVersion > 0 && options.rawLeaves === undefined) {
@@ -74,7 +74,7 @@ module.exports = async function * (source, ipld, options = {}) {
     treeBuilder = require('./tree-builder')
   }
 
-  for await (const entry of treeBuilder(parallelBatch(dagBuilder(source, ipld, opts), opts.fileImportConcurrency), ipld, opts)) {
+  for await (const entry of treeBuilder(parallelBatch(dagBuilder(source, block, opts), opts.fileImportConcurrency), block, opts)) {
     yield {
       cid: entry.cid,
       path: entry.path,

--- a/packages/ipfs-unixfs-importer/src/tree-builder.js
+++ b/packages/ipfs-unixfs-importer/src/tree-builder.js
@@ -51,7 +51,7 @@ async function addToTree (elem, tree, options) {
   return tree
 }
 
-async function * treeBuilder (source, ipld, options) {
+async function * treeBuilder (source, block, options) {
   let tree = new DirFlat({
     root: true,
     dir: true,
@@ -94,7 +94,7 @@ async function * treeBuilder (source, ipld, options) {
     return
   }
 
-  yield * tree.flush(tree.path, ipld)
+  yield * tree.flush(tree.path, block)
 }
 
 module.exports = treeBuilder

--- a/packages/ipfs-unixfs-importer/test/builder-dir-sharding.spec.js
+++ b/packages/ipfs-unixfs-importer/test/builder-dir-sharding.spec.js
@@ -11,12 +11,15 @@ const IPLD = require('ipld')
 const inMemory = require('ipld-in-memory')
 const all = require('it-all')
 const last = require('it-last')
+const blockApi = require('./helpers/block')
 
 describe('builder: directory sharding', () => {
   let ipld
+  let block
 
   before(async () => {
     ipld = await inMemory(IPLD)
+    block = blockApi(ipld)
   })
 
   describe('basic dirbuilder', () => {
@@ -25,7 +28,7 @@ describe('builder: directory sharding', () => {
       const nodes = await all(importer([{
         path: 'a/b',
         content
-      }], ipld, {
+      }], block, {
         shardSplitThreshold: Infinity // never shard
       }))
 
@@ -46,7 +49,7 @@ describe('builder: directory sharding', () => {
       const nodes = await all(importer([{
         path: 'a/b',
         content: Buffer.from('i have the best bytes')
-      }], ipld, {
+      }], block, {
         shardSplitThreshold: 0 // always shard
       }))
 
@@ -64,7 +67,7 @@ describe('builder: directory sharding', () => {
       const nodes = await all(importer([{
         path: 'a/b',
         content: Buffer.from(content)
-      }], ipld, {
+      }], block, {
         shardSplitThreshold: Infinity // never shard
       }))
 
@@ -92,7 +95,7 @@ describe('builder: directory sharding', () => {
       const nodes = await all(importer([{
         path: 'a/b',
         content: Buffer.from(content)
-      }], ipld, {
+      }], block, {
         shardSplitThreshold: 0 // always shard
       }))
 
@@ -133,7 +136,7 @@ describe('builder: directory sharding', () => {
         }
       }
 
-      const nodes = await all(importer(source, ipld))
+      const nodes = await all(importer(source, block))
 
       expect(nodes.length).to.equal(maxDirs + 1)
       const last = nodes[nodes.length - 1]
@@ -152,7 +155,7 @@ describe('builder: directory sharding', () => {
         }
       }
 
-      const nodes = await all(importer(source, ipld))
+      const nodes = await all(importer(source, block))
 
       expect(nodes.length).to.equal(maxDirs + 1) // files plus the containing directory
 
@@ -204,7 +207,7 @@ describe('builder: directory sharding', () => {
         }
       }
 
-      const node = await last(importer(source, ipld))
+      const node = await last(importer(source, block))
       expect(node.path).to.equal('big')
 
       rootHash = node.cid

--- a/packages/ipfs-unixfs-importer/test/builder-only-hash.spec.js
+++ b/packages/ipfs-unixfs-importer/test/builder-only-hash.spec.js
@@ -8,19 +8,22 @@ const IPLD = require('ipld')
 const inMemory = require('ipld-in-memory')
 const builder = require('../src/dag-builder')
 const all = require('it-all')
+const blockApi = require('./helpers/block')
 
 describe('builder: onlyHash', () => {
   let ipld
+  let block
 
   before(async () => {
     ipld = await inMemory(IPLD)
+    block = blockApi(ipld)
   })
 
   it('will only chunk and hash if passed an "onlyHash" option', async () => {
     const nodes = await all(builder([{
       path: 'foo.txt',
       content: Buffer.from([0, 1, 2, 3, 4])
-    }], ipld, {
+    }], block, {
       onlyHash: true,
       chunker: 'fixed',
       strategy: 'balanced',

--- a/packages/ipfs-unixfs-importer/test/builder.spec.js
+++ b/packages/ipfs-unixfs-importer/test/builder.spec.js
@@ -10,15 +10,18 @@ const inMemory = require('ipld-in-memory')
 const UnixFS = require('ipfs-unixfs')
 const builder = require('../src/dag-builder')
 const first = require('it-first')
+const blockApi = require('./helpers/block')
 
 describe('builder', () => {
   let ipld
+  let block
 
   before(async () => {
     ipld = await inMemory(IPLD)
+    block = blockApi(ipld)
   })
 
-  const testMultihashes = Object.keys(mh.names).slice(1, 40)
+  const testMultihashes = Object.keys(mh.names).slice(1, 10)
   const opts = {
     strategy: 'flat',
     chunker: 'fixed',
@@ -43,7 +46,7 @@ describe('builder', () => {
         content: Buffer.from(content)
       }
 
-      const imported = await (await first(builder([inputFile], ipld, options)))()
+      const imported = await (await first(builder([inputFile], block, options)))()
 
       expect(imported).to.exist()
 
@@ -74,7 +77,7 @@ describe('builder', () => {
         content: Buffer.alloc(262144 + 5).fill(1)
       }
 
-      const imported = await (await first(builder([inputFile], ipld, options)))()
+      const imported = await (await first(builder([inputFile], block, options)))()
 
       expect(imported).to.exist()
       expect(mh.decode(imported.cid.multihash).name).to.equal(hashAlg)
@@ -94,7 +97,7 @@ describe('builder', () => {
         content: null
       }
 
-      const imported = await (await first(builder([Object.assign({}, inputFile)], ipld, options)))()
+      const imported = await (await first(builder([Object.assign({}, inputFile)], block, options)))()
 
       expect(mh.decode(imported.cid.multihash).name).to.equal(hashAlg)
 

--- a/packages/ipfs-unixfs-importer/test/chunker-custom.spec.js
+++ b/packages/ipfs-unixfs-importer/test/chunker-custom.spec.js
@@ -9,6 +9,7 @@ const expect = chai.expect
 const IPLD = require('ipld')
 const inMemory = require('ipld-in-memory')
 const mc = require('multicodec')
+const blockApi = require('./helpers/block')
 
 // eslint bug https://github.com/eslint/eslint/issues/12459
 // eslint-disable-next-line require-await
@@ -19,11 +20,12 @@ const iter = async function * () {
 
 describe('custom chunker', function () {
   let inmem
+  let block
 
   const fromPartsTest = (iter, size) => async () => {
     for await (const part of importer([{
       content: iter()
-    }], inmem, {
+    }], block, {
       chunkValidator: source => source,
       chunker: source => source,
       bufferImporter: async function * (file, source, ipld, options) {
@@ -38,12 +40,13 @@ describe('custom chunker', function () {
 
   before(async () => {
     inmem = await inMemory(IPLD)
+    block = blockApi(inmem)
   })
 
   it('keeps custom chunking', async () => {
     const chunker = source => source
     const content = iter()
-    for await (const part of importer([{ path: 'test', content }], inmem, {
+    for await (const part of importer([{ path: 'test', content }], block, {
       chunker
     })) {
       expect(part.size).to.equal(116)

--- a/packages/ipfs-unixfs-importer/test/hash-parity-with-go-ipfs.spec.js
+++ b/packages/ipfs-unixfs-importer/test/hash-parity-with-go-ipfs.spec.js
@@ -10,6 +10,7 @@ const IPLD = require('ipld')
 const inMemory = require('ipld-in-memory')
 const randomByteStream = require('./helpers/finite-pseudorandom-byte-stream')
 const first = require('it-first')
+const blockApi = require('./helpers/block')
 
 const strategies = [
   'flat',
@@ -30,9 +31,11 @@ strategies.forEach(strategy => {
 
   describe('go-ipfs interop using importer:' + strategy, () => {
     let ipld
+    let block
 
     before(async () => {
       ipld = await inMemory(IPLD)
+      block = blockApi(ipld)
     })
 
     it('yields the same tree as go-ipfs', async function () {
@@ -43,7 +46,7 @@ strategies.forEach(strategy => {
         content: randomByteStream(45900000, 7382)
       }]
 
-      const file = await first(importer(source, ipld, options))
+      const file = await first(importer(source, block, options))
 
       expect(file.cid.toBaseEncodedString()).to.be.equal(expectedHashes[strategy])
     })

--- a/packages/ipfs-unixfs-importer/test/helpers/block.js
+++ b/packages/ipfs-unixfs-importer/test/helpers/block.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const DAG_PB = require('ipld-dag-pb')
+const multicodec = require('multicodec')
+const mh = require('multihashing-async').multihash
+
+module.exports = (ipld) => {
+  // make ipld behave like the block api, some tests need to pull
+  // data from ipld so can't use use a simple hash
+  return {
+    put: async (buf, { cid }) => {
+      const multihash = mh.decode(cid.multihash)
+
+      if (cid.codec === 'dag-pb') {
+        buf = DAG_PB.util.deserialize(buf)
+      }
+
+      await ipld.put(buf, cid.codec === 'dag-pb' ? multicodec.DAG_PB : multicodec.RAW, {
+        cidVersion: cid.version,
+        hashAlg: multihash.code
+      })
+
+      return { cid, data: buf }
+    },
+    get: async (cid, options) => {
+      const node = await ipld.get(cid, options)
+
+      if (cid.codec === 'dag-pb') {
+        return node.serialize()
+      }
+
+      return { cid, data: node }
+    }
+  }
+}

--- a/packages/ipfs-unixfs-importer/test/import-export-nested-dir.spec.js
+++ b/packages/ipfs-unixfs-importer/test/import-export-nested-dir.spec.js
@@ -9,13 +9,16 @@ const inMemory = require('ipld-in-memory')
 const all = require('it-all')
 const importer = require('../src')
 const exporter = require('ipfs-unixfs-exporter')
+const blockApi = require('./helpers/block')
 
 describe('import and export: directory', () => {
   const rootHash = 'QmdCrquDwd7RfZ6GCZFEVADwe8uyyw1YmF9mtAB7etDgmK'
   let ipld
+  let block
 
   before(async () => {
     ipld = await inMemory(IPLD)
+    block = blockApi(ipld)
   })
 
   it('imports', async function () {
@@ -35,7 +38,7 @@ describe('import and export: directory', () => {
       content: Buffer.from('cream')
     }]
 
-    const files = await all(importer(source, ipld))
+    const files = await all(importer(source, block))
 
     expect(files.map(normalizeNode).sort(byPath)).to.be.eql([{
       path: 'a/b/h',

--- a/packages/ipfs-unixfs-importer/test/import-export.spec.js
+++ b/packages/ipfs-unixfs-importer/test/import-export.spec.js
@@ -10,6 +10,7 @@ const inMemory = require('ipld-in-memory')
 const loadFixture = require('aegir/fixtures')
 const isNode = require('detect-node')
 const bigFile = loadFixture((isNode ? __dirname : 'test') + '/fixtures/1.2MiB.txt')
+const blockApi = require('./helpers/block')
 
 const importer = require('../src')
 const exporter = require('ipfs-unixfs-exporter')
@@ -28,16 +29,18 @@ describe('import and export', function () {
 
     describe('using builder: ' + strategy, () => {
       let ipld
+      let block
 
       before(async () => {
         ipld = await inMemory(IPLD)
+        block = blockApi(ipld)
       })
 
       it('imports and exports', async () => {
         const path = `${strategy}-big.dat`
         const values = [{ path: path, content: bigFile }]
 
-        for await (const file of importer(values, ipld, importerOptions)) {
+        for await (const file of importer(values, block, importerOptions)) {
           expect(file.path).to.eql(path)
 
           const result = await exporter(file.cid, ipld)


### PR DESCRIPTION
This improves reusability of the module as it can be used by passing part of an `ipfs` or `ipfs-http-client` instance in.

It also means we no longer double serialize blocks before adding them which delivers a very small performance increase (1-2%).

Finally also documents the `pin` and `preload` arguments.

BREAKING CHANGE:

The importer takes a `pin` argument (previously undocumented) - it used to default to `true` but since this switches to use the block API the default has changed to `false`, as the typical usage pattern is to pin the root block of a DAG recursively instead of every block that makes up the DAG.