### PR TITLE
fix: ignore high mode bits passed to constructor

### DIFF
--- a/packages/ipfs-unixfs-exporter/package.json
+++ b/packages/ipfs-unixfs-exporter/package.json
@@ -36,7 +36,7 @@
   "homepage": "https://github.com/ipfs/js-ipfs-unixfs#readme",
   "devDependencies": {
     "abort-controller": "^3.0.0",
-    "aegir": "^21.9.0",
+    "aegir": "^22.0.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "detect-node": "^2.0.4",

--- a/packages/ipfs-unixfs-importer/package.json
+++ b/packages/ipfs-unixfs-importer/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/ipfs/js-ipfs-unixfs#readme",
   "devDependencies": {
-    "aegir": "^21.9.0",
+    "aegir": "^22.0.0",
     "chai": "^4.2.0",
     "cids": "^0.8.0",
     "detect-node": "^2.0.4",

--- a/packages/ipfs-unixfs/package.json
+++ b/packages/ipfs-unixfs/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/ipfs/js-ipfs-unixfs#readme",
   "devDependencies": {
-    "aegir": "^21.9.0",
+    "aegir": "^22.0.0",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "nyc": "^15.0.0"

--- a/packages/ipfs-unixfs/src/index.js
+++ b/packages/ipfs-unixfs/src/index.js
@@ -129,13 +129,18 @@ class Data {
   static unmarshal (marshaled) {
     const decoded = unixfsData.decode(marshaled)
 
-    return new Data({
+    const data = new Data({
       type: types[decoded.Type],
       data: decoded.hasData() ? decoded.Data : undefined,
       blockSizes: decoded.blocksizes,
       mode: decoded.hasMode() ? decoded.mode : undefined,
       mtime: decoded.hasMtime() ? decoded.mtime : undefined
     })
+
+    // make sure we honor the original mode
+    data._originalMode = decoded.hasMode() ? decoded.mode : undefined
+
+    return data
   }
 
   constructor (...args) {
@@ -158,7 +163,6 @@ class Data {
     this.hashType = hashType
     this.fanout = fanout
     this.blockSizes = blockSizes || []
-    this._originalMode = mode
 
     const parsedMode = parseMode(mode)
 


### PR DESCRIPTION
The UnixFS Spec [says](https://github.com/ipfs/specs/blob/master/UNIXFS.md#metadata) high mode bits not defined in the version of the spec supported by a given implementation should be ignored but also persisted to ensure forwards compatibility.  The change here:

1. Ignores high bits passed to the constructor
1. Respects high bits read out of a protobuf though does not expose them
1. Writes high bits back to a protobuf but only if they were read from a protobuf to begin with