### PR TITLE
chore: upgrade to dag-pb that supports Uint8Array

### DIFF
--- a/packages/ipfs-unixfs-exporter/package.json
+++ b/packages/ipfs-unixfs-exporter/package.json
@@ -43,7 +43,7 @@
     "dirty-chai": "^2.0.1",
     "ipfs-unixfs-importer": "^2.0.1",
     "ipld": "^0.26.1",
-    "ipld-dag-pb": "^0.18.5",
+    "ipld-dag-pb": "^0.19.0",
     "ipld-in-memory": "^4.0.0",
     "it-all": "^1.0.1",
     "it-buffer-stream": "^1.0.2",

--- a/packages/ipfs-unixfs-importer/package.json
+++ b/packages/ipfs-unixfs-importer/package.json
@@ -56,7 +56,7 @@
     "err-code": "^2.0.0",
     "hamt-sharding": "^1.0.0",
     "ipfs-unixfs": "^1.0.2",
-    "ipld-dag-pb": "^0.18.5",
+    "ipld-dag-pb": "^0.19.0",
     "it-all": "^1.0.1",
     "it-batch": "^1.0.3",
     "it-first": "^1.0.1",


### PR DESCRIPTION
Updates to new dag-pb to incorporate changes that allows passing `Uint8Array`s in place of node `Buffer`s.

@achingbrain I'm not sure what's the deal with this file https://github.com/ipfs/js-ipfs-unixfs/blob/master/packages/ipfs-unixfs-exporter/package-lock.json but it doesn't seem to get updated when running `npm install` in the root & seems to break `npm istall` when run in the exporter dir.