### PR TITLE
chore: downgrade merge-options

### DIFF
--- a/packages/ipfs-unixfs-importer/package.json
+++ b/packages/ipfs-unixfs-importer/package.json
@@ -58,7 +58,7 @@
     "it-batch": "^1.0.3",
     "it-first": "^1.0.1",
     "it-parallel-batch": "^1.0.3",
-    "merge-options": "^3.0.1",
+    "merge-options": "^2.0.0",
     "multihashing-async": "^2.0.0",
     "rabin-wasm": "^0.1.1",
     "uint8arrays": "^1.1.0"


### PR DESCRIPTION
Downgrades merge-options because v3 removed node 12 support.

Refs: https://github.com/ipfs/js-ipfs/issues/3270
Refs: https://github.com/schnittstabil/merge-options/issues/23