### PR TITLE
feat: pass file name along with progress

### DIFF
--- a/packages/ipfs-unixfs-importer/src/dag-builder/file/buffer-importer.js
+++ b/packages/ipfs-unixfs-importer/src/dag-builder/file/buffer-importer.js
@@ -9,7 +9,7 @@ const {
 async function * bufferImporter (file, source, block, options) {
   for await (let buffer of source) {
     yield async () => {
-      options.progress(buffer.length)
+      options.progress(buffer.length, file.path)
       let unixfs
 
       const opts = {

--- a/packages/ipfs-unixfs-importer/test/importer.spec.js
+++ b/packages/ipfs-unixfs-importer/test/importer.spec.js
@@ -646,6 +646,7 @@ strategies.forEach((strategy) => {
 
     it('will call an optional progress function', async () => {
       const maxChunkSize = 2048
+      const path = '1.2MiB.txt'
 
       const options = {
         progress: spy(),
@@ -653,12 +654,12 @@ strategies.forEach((strategy) => {
       }
 
       await all(importer([{
-        path: '1.2MiB.txt',
+        path,
         content: bigFile
       }], block, options))
 
       expect(options.progress.called).to.equal(true)
-      expect(options.progress.args[0][0]).to.equal(maxChunkSize)
+      expect(options.progress.args[0]).to.deep.equal([maxChunkSize, path])
     })
 
     it('will import files with CID version 1', async () => {


### PR DESCRIPTION
When importing and reporting progress we pass the current filename as part of progress events in the [http server](https://github.com/ipfs/js-ipfs/blob/master/packages/ipfs-http-server/src/api/resources/files-regular.js#L254-L255)

To do the same thing with core we need access to the filename as part of the progress handler so here we add that.