### PR TITLE
fix: just do what the user asked

### DIFF
--- a/packages/ipfs-unixfs-importer/src/index.js
+++ b/packages/ipfs-unixfs-importer/src/index.js
@@ -36,28 +36,6 @@ const defaultOptions = {
 module.exports = async function * (source, block, options = {}) {
   const opts = mergeOptions(defaultOptions, options)
 
-  if (options.cidVersion > 0 && options.rawLeaves === undefined) {
-    // if the cid version is 1 or above, use raw leaves as this is
-    // what go does.
-    opts.rawLeaves = true
-  }
-
-  if (options.hashAlg !== undefined && options.rawLeaves === undefined) {
-    // if a non-default hash alg has been specified, use raw leaves as this is
-    // what go does.
-    opts.rawLeaves = true
-  }
-
-  // go-ifps trickle dag defaults to unixfs raw leaves, balanced dag defaults to file leaves
-  if (options.strategy === 'trickle') {
-    opts.leafType = 'raw'
-    opts.reduceSingleLeafToSelf = false
-  }
-
-  if (options.format) {
-    opts.codec = options.format
-  }
-
   let dagBuilder
 
   if (typeof options.dagBuilder === 'function') {

--- a/packages/ipfs-unixfs-importer/test/hash-parity-with-go-ipfs.spec.js
+++ b/packages/ipfs-unixfs-importer/test/hash-parity-with-go-ipfs.spec.js
@@ -27,6 +27,12 @@ strategies.forEach(strategy => {
     strategy: strategy
   }
 
+  if (strategy === 'trickle') {
+    // replicate go-ipfs behaviour
+    options.leafType = 'raw'
+    options.reduceSingleLeafToSelf = false
+  }
+
   describe('go-ipfs interop using importer:' + strategy, () => {
     let ipld
     let block

--- a/packages/ipfs-unixfs-importer/test/importer.spec.js
+++ b/packages/ipfs-unixfs-importer/test/importer.spec.js
@@ -319,6 +319,12 @@ strategies.forEach((strategy) => {
       strategy: strategy
     }
 
+    if (strategy === 'trickle') {
+      // replicate go-ipfs behaviour
+      options.leafType = 'raw'
+      options.reduceSingleLeafToSelf = false
+    }
+
     before(async () => {
       ipld = await inMemory(IPLD)
       block = blockApi(ipld)


### PR DESCRIPTION
We change some defaults based on the CID version passed, this seems
like the wrong approach and debugging problems turns into whack-a-mole.

Let the calling code decide the settings for the various knobs and levers
instead.

BREAKING CHANGES: We previously did things like set rawLeaves to true based
  on the CID version, now we do not.