### PR TITLE
feat: support multiple roots

### DIFF
--- a/packages/ipfs-unixfs-importer/test/importer.spec.js
+++ b/packages/ipfs-unixfs-importer/test/importer.spec.js
@@ -376,20 +376,16 @@ strategies.forEach((strategy) => {
       expect(files[0].cid.toBaseEncodedString()).to.eql('QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH')
     })
 
-    it('fails on more than one root', async () => {
-      try {
-        await all(importer([{
-          path: 'beep/200Bytes.txt',
-          content: smallFile
-        }, {
-          path: 'boop/200Bytes.txt',
-          content: bigFile
-        }], block, options))
+    it('supports more than one root', async () => {
+      const files = await all(importer([{
+        path: '200Bytes.txt',
+        content: smallFile
+      }, {
+        path: '200Bytes.txt',
+        content: bigFile
+      }], block, options))
 
-        throw new Error('No error was thrown')
-      } catch (err) {
-        expect(err.code).to.equal('ERR_MORE_THAN_ONE_ROOT')
-      }
+      expect(files).to.have.lengthOf(2)
     })
 
     it('accepts strings as content', async () => {


### PR DESCRIPTION
It's never been clear why js-ipfs doesn't support multiple roots when
go-ipfs does.

This PR removes the check for multiple roots so if you import five
files without a leading directory in their paths or without the `wrapWithDirectory`
option, you'll get five CIDs back instead of an error.

BREAKING CHANGE: Importing files that would result in multiple roots no longer throws an error