### PR TITLE
chore: fix rc publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ yarn.lock
 **/*.log
 test/repo-tests*
 **/bundle.js
+package-lock.json
 
 # Logs
 logs

--- a/lerna.json
+++ b/lerna.json
@@ -14,7 +14,8 @@
     "publish": {
       "message": "chore: publish",
       "conventionalCommits": true,
-      "createRelease": "github"
+      "createRelease": "github",
+      "verifyAccess": false
     }
   }
 }


### PR DESCRIPTION
Lerna doesn't work with npm automation tokens out of the box, need
to disable auth verification for the time being.

Refs: https://github.com/lerna/lerna/issues/2788