### PR TITLE
chore: use npm 7 workspaces instead of lerna bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ yarn.lock
 test/repo-tests*
 **/bundle.js
 package-lock.json
+tsconfig-types.aegir.json
 
 # Logs
 logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ os:
   - windows
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then npm config set loglevel verbose ; fi
   # prevents windows error: npm ERR! ... git-sh-setup: file not found
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then export PATH=/c/PROGRA~1/Git/usr/bin:/c/PROGRA~1/Git/mingw64/libexec/git-core:$PATH ; fi
   # upgrading npm on travis/windows/node 14 is completely broken

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then export PATH=/c/PROGRA~1/Git/usr/bin:/c/PROGRA~1/Git/mingw64/libexec/git-core:$PATH ; fi
   # upgrading npm on travis/windows/node 14 is completely broken
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then export NODE_INSTALL_DIR=`npm prefix -g` ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then mkdir $NODE_INSTALL_DIR/node_modules ; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then mv $NODE_INSTALL_DIR/node_modules $NODE_INSTALL_DIR/node_modules_old ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then mkdir $NODE_INSTALL_DIR/node_modules ; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then rm -f $NODE_INSTALL_DIR/npm $NODE_INSTALL_DIR/npm.cmd $NODE_INSTALL_DIR/npm.ps1 $NODE_INSTALL_DIR/npx $NODE_INSTALL_DIR/npx.cmd $NODE_INSTALL_DIR/npx.ps1 ; fi
   # workspaces require npm 7 or above
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then node $NODE_INSTALL_DIR/node_modules_old/npm/bin/npm-cli.js i -g npm@latest ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ stages:
   - release
 
 node_js:
-  - 'node'
   - 'lts/*'
+  - 'node'
 
 os:
   - linux
@@ -25,8 +25,19 @@ os:
   - windows
 
 before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then npm config set loglevel verbose ; fi
   # prevents windows error: npm ERR! ... git-sh-setup: file not found
-  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then export PATH=/c/PROGRA~1/Git/usr/bin:/c/PROGRA~1/Git/mingw64/libexec/git-core:$PATH ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then export PATH=/c/PROGRA~1/Git/usr/bin:/c/PROGRA~1/Git/mingw64/libexec/git-core:$PATH ; fi
+  # upgrading npm on travis/windows/node 14 is completely broken
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then export NODE_INSTALL_DIR=`npm prefix -g` ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then mkdir $NODE_INSTALL_DIR/node_modules ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then mv $NODE_INSTALL_DIR/node_modules $NODE_INSTALL_DIR/node_modules_old ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then rm -f $NODE_INSTALL_DIR/npm $NODE_INSTALL_DIR/npm.cmd $NODE_INSTALL_DIR/npm.ps1 $NODE_INSTALL_DIR/npx $NODE_INSTALL_DIR/npx.cmd $NODE_INSTALL_DIR/npx.ps1 ; fi
+  # workspaces require npm 7 or above
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then node $NODE_INSTALL_DIR/node_modules_old/npm/bin/npm-cli.js i -g npm@latest ; fi
+  - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then npm install -g npm@latest ; fi
+  # allow windows to run scripts with node 14 and npm 7 (may not be necessary when node 14 is no longer lts)
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then npm config set script-shell c:/PROGRA~1/Git/bin/bash.exe ; fi
 
 script: npx nyc -s npm run test -- -- -- -t node --bail
 after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
@@ -36,6 +47,7 @@ jobs:
     - stage: check
       name: linting
       script:
+        - npm --version
         - npm run lint
 
     - stage: check

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "1.0.0",
   "description": "JS implementation of the IPFS UnixFS",
   "scripts": {
-    "postinstall": "lerna bootstrap",
-    "reset": "lerna run clean && rm -rf packages/*/node_modules node_modules",
+    "reset": "lerna run clean && rimraf packages/*/node_modules node_modules",
     "test": "lerna run test",
     "coverage": "lerna run coverage",
     "prepare": "lerna run prepare",
@@ -17,6 +16,7 @@
     "update-contributors": "aegir release --lint=false --test=false --bump=false --build=false --changelog=false --commit=false --tag=false --push=false --ghrelease=false --docs=false --publish=false"
   },
   "devDependencies": {
+    "aegir": "^30.3.0",
     "lerna": "^3.22.1"
   },
   "repository": {
@@ -47,5 +47,11 @@
     "Diogo Silva <fsdiogo@gmail.com>",
     "jbenet <juan@benet.ai>",
     "Bernard Mordan <bernard@tableflip.io>"
-  ]
+  ],
+  "workspaces": [
+    "packages/*"
+  ],
+  "engines": {
+    "npm": ">=7.0.0"
+  }
 }

--- a/packages/ipfs-unixfs-exporter/package.json
+++ b/packages/ipfs-unixfs-exporter/package.json
@@ -10,10 +10,10 @@
   "scripts": {
     "prepare": "aegir build --no-bundle",
     "test": "aegir test",
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "lint": "aegir lint",
     "coverage": "nyc -s npm run test -t node && nyc report --reporter=html",
-    "depcheck": "aegir dep-check -i @types/mocha -i @types/sinon -i nyc -i abort-controller"
+    "depcheck": "aegir dep-check -i @types/mocha -i @types/sinon -i nyc -i abort-controller -i rimraf"
   },
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/ipfs/js-ipfs-unixfs#readme",
   "devDependencies": {
-    "@types/mocha": "^8.2.0",
+    "@types/mocha": "^8.2.1",
     "@types/sinon": "^9.0.10",
     "abort-controller": "^3.0.0",
     "aegir": "^30.3.0",
@@ -41,23 +41,24 @@
     "ipld": "^0.28.0",
     "ipld-dag-pb": "^0.21.0",
     "ipld-in-memory": "^7.0.0",
-    "it-all": "^1.0.1",
+    "it-all": "^1.0.5",
     "it-buffer-stream": "^2.0.0",
-    "it-first": "^1.0.1",
+    "it-first": "^1.0.6",
     "merge-options": "^3.0.4",
-    "multicodec": "^2.0.0",
+    "multicodec": "^2.1.0",
     "native-abort-controller": "^1.0.3",
     "nyc": "^15.0.0",
-    "sinon": "^9.0.10",
-    "uint8arrays": "^2.0.5"
+    "rimraf": "^3.0.2",
+    "sinon": "^9.2.4",
+    "uint8arrays": "^2.1.2"
   },
   "dependencies": {
     "cids": "^1.1.5",
-    "err-code": "^3.0.0",
+    "err-code": "^3.0.1",
     "hamt-sharding": "^2.0.0",
     "ipfs-unixfs": "^3.0.0",
-    "it-last": "^1.0.1",
-    "multihashing-async": "^2.0.0"
+    "it-last": "^1.0.5",
+    "multihashing-async": "^2.1.0"
   },
   "types": "dist/src/index.d.ts",
   "files": [

--- a/packages/ipfs-unixfs-importer/package.json
+++ b/packages/ipfs-unixfs-importer/package.json
@@ -10,10 +10,10 @@
   "scripts": {
     "prepare": "aegir build --no-bundle",
     "test": "aegir test",
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "lint": "aegir lint",
     "coverage": "nyc -s npm run test -t node && nyc report --reporter=html",
-    "depcheck": "aegir dep-check -i @types/mocha -i nyc"
+    "depcheck": "aegir dep-check -i @types/mocha -i nyc -i rimraf"
   },
   "repository": {
     "type": "git",
@@ -32,29 +32,30 @@
   },
   "homepage": "https://github.com/ipfs/js-ipfs-unixfs#readme",
   "devDependencies": {
-    "@types/mocha": "^8.2.0",
+    "@types/mocha": "^8.2.1",
     "aegir": "^30.3.0",
     "ipld": "^0.28.0",
     "ipld-in-memory": "^7.0.0",
     "it-buffer-stream": "^2.0.0",
-    "multicodec": "^2.0.0",
-    "nyc": "^15.0.0"
+    "multicodec": "^2.1.0",
+    "nyc": "^15.0.0",
+    "rimraf": "^3.0.2"
   },
   "dependencies": {
-    "bl": "^4.0.0",
+    "bl": "^4.1.0",
     "cids": "^1.1.5",
-    "err-code": "^3.0.0",
+    "err-code": "^3.0.1",
     "hamt-sharding": "^2.0.0",
     "ipfs-unixfs": "^3.0.0",
     "ipld-dag-pb": "^0.21.0",
-    "it-all": "^1.0.1",
-    "it-batch": "^1.0.3",
-    "it-first": "^1.0.1",
-    "it-parallel-batch": "^1.0.3",
-    "merge-options": "^3.0.3",
-    "multihashing-async": "^2.0.0",
-    "rabin-wasm": "^0.1.1",
-    "uint8arrays": "^2.0.5"
+    "it-all": "^1.0.5",
+    "it-batch": "^1.0.8",
+    "it-first": "^1.0.6",
+    "it-parallel-batch": "^1.0.9",
+    "merge-options": "^3.0.4",
+    "multihashing-async": "^2.1.0",
+    "rabin-wasm": "^0.1.4",
+    "uint8arrays": "^2.1.2"
   },
   "types": "dist/src/index.d.ts",
   "files": [

--- a/packages/ipfs-unixfs/package.json
+++ b/packages/ipfs-unixfs/package.json
@@ -17,7 +17,7 @@
     "clean": "rimraf ./dist",
     "lint": "aegir lint",
     "coverage": "nyc -s aegir test -t node && nyc report --reporter=html",
-    "depcheck": "aegir dep-check -i mkdirp -i @types/mocha -i nyc -i npm-run-all -copy"
+    "depcheck": "aegir dep-check -i mkdirp -i @types/mocha -i nyc -i npm-run-all -i copy"
   },
   "repository": {
     "type": "git",

--- a/packages/ipfs-unixfs/package.json
+++ b/packages/ipfs-unixfs/package.json
@@ -12,12 +12,12 @@
     "prepare:proto": "pbjs -t static-module -w commonjs --force-number --no-verify --no-delimited --no-create --no-beautify --no-defaults --lint eslint-disable -o src/unixfs.js ./src/unixfs.proto",
     "prepare:proto:types": "pbts -o src/unixfs.d.ts src/unixfs.js",
     "prepare:types": "aegir build --no-bundle",
-    "prepare:copy": "cp ./src/*.d.ts ./dist/src",
+    "prepare:copy": "copy ./src/*.d.ts ./dist/src",
     "test": "aegir test",
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "lint": "aegir lint",
     "coverage": "nyc -s aegir test -t node && nyc report --reporter=html",
-    "depcheck": "aegir dep-check -i mkdirp -i protobufjs -i @types/mocha -i nyc -i npm-run-all"
+    "depcheck": "aegir dep-check -i mkdirp -i @types/mocha -i nyc -i npm-run-all -copy"
   },
   "repository": {
     "type": "git",
@@ -36,15 +36,16 @@
   },
   "homepage": "https://github.com/ipfs/js-ipfs-unixfs#readme",
   "devDependencies": {
-    "@types/mocha": "^8.2.0",
+    "@types/mocha": "^8.2.1",
     "aegir": "^30.3.0",
+    "copy": "^0.3.2",
     "mkdirp": "^1.0.4",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.0.0",
-    "uint8arrays": "^2.0.5"
+    "uint8arrays": "^2.1.2"
   },
   "dependencies": {
-    "err-code": "^3.0.0",
+    "err-code": "^3.0.1",
     "protobufjs": "^6.10.2"
   },
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
It's faster - running `time npm i` shows a nice speed up:

lerna

```
npm timing command:install Completed in 183859ms
npm timing npm Completed in 184077ms
npm info ok

real	3m4.246s
user	2m48.066s
sys	0m58.948s
```

npm7 + workspaces

```
npm timing command:install Completed in 101724ms
npm timing npm Completed in 101914ms
npm info ok

real	1m42.075s
user	1m52.422s
sys	0m46.022s
```

The downside is it requires npm7 - it's bundled with node 15 but will
require users up upgrade if they are using node 14 or below.