### PR TITLE
chore: update multiformats

### DIFF
--- a/packages/ipfs-unixfs-exporter/package.json
+++ b/packages/ipfs-unixfs-exporter/package.json
@@ -65,7 +65,7 @@
     "it-last": "^1.0.5",
     "multiformats": "^9.4.2",
     "murmurhash3js-revisited": "^3.0.0",
-    "uint8arrays": "^2.1.5"
+    "uint8arrays": "^2.1.7"
   },
   "types": "dist/src/index.d.ts",
   "files": [

--- a/packages/ipfs-unixfs-exporter/package.json
+++ b/packages/ipfs-unixfs-exporter/package.json
@@ -63,7 +63,7 @@
     "interface-blockstore": "^1.0.0",
     "ipfs-unixfs": "^5.0.0",
     "it-last": "^1.0.5",
-    "multiformats": "^9.0.4",
+    "multiformats": "^9.4.2",
     "murmurhash3js-revisited": "^3.0.0",
     "uint8arrays": "^2.1.5"
   },

--- a/packages/ipfs-unixfs-importer/package.json
+++ b/packages/ipfs-unixfs-importer/package.json
@@ -60,7 +60,7 @@
     "multiformats": "^9.4.2",
     "murmurhash3js-revisited": "^3.0.0",
     "rabin-wasm": "^0.1.4",
-    "uint8arrays": "^2.1.2"
+    "uint8arrays": "^2.1.7"
   },
   "types": "dist/src/index.d.ts",
   "files": [

--- a/packages/ipfs-unixfs-importer/package.json
+++ b/packages/ipfs-unixfs-importer/package.json
@@ -57,7 +57,7 @@
     "it-first": "^1.0.6",
     "it-parallel-batch": "^1.0.9",
     "merge-options": "^3.0.4",
-    "multiformats": "^9.0.4",
+    "multiformats": "^9.4.2",
     "murmurhash3js-revisited": "^3.0.0",
     "rabin-wasm": "^0.1.4",
     "uint8arrays": "^2.1.2"


### PR DESCRIPTION
Let's force update multiformats. Well, I know in theory this is not needed but skypack does not do a good job with getting latest releases sometimes: https://codepen.io/vascosantos/pen/abWWbJe?editors=0011

![image](https://user-images.githubusercontent.com/7295071/125923376-15dcbbca-1d09-4199-abd6-48143ffa8752.png)

Currently this module does not work in skypack, but I would like to see if https://github.com/multiformats/js-multiformats/pull/105 also fixes it.