### PR TITLE
fix: update import types

### DIFF
--- a/packages/ipfs-unixfs-exporter/test/importer.spec.js
+++ b/packages/ipfs-unixfs-exporter/test/importer.spec.js
@@ -392,10 +392,10 @@ strategies.forEach((strategy) => {
 
     it('fails on an iterator that yields bad content', async () => {
       try {
+        // @ts-expect-error bad content
         await all(importer([{
           path: '200Bytes.txt',
           content: {
-            // @ts-expect-error bad content
             [Symbol.iterator]: function * () {
               yield 7
             }

--- a/packages/ipfs-unixfs-importer/src/types.d.ts
+++ b/packages/ipfs-unixfs-importer/src/types.d.ts
@@ -6,7 +6,7 @@ import { Blockstore } from 'interface-blockstore'
 
 interface ImportCandidate {
   path?: string
-  content?: AsyncIterable<Uint8Array>
+  content?: AsyncIterable<Uint8Array> | Iterable<Uint8Array> | Uint8Array
   mtime?: Mtime
   mode?: number
 }


### PR DESCRIPTION
This module supports more than just `AsyncIterable<Uint8Array>` so update the types to reflect that.

These sigs are used by the `interface-ipfs-core` test suite.