### PR TITLE
fix: types with ipjs build

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "update-contributors": "aegir release --lint=false --test=false --bump=false --build=false --changelog=false --commit=false --tag=false --push=false --ghrelease=false --docs=false --publish=false"
   },
   "devDependencies": {
-    "lerna": "^3.22.1"
+    "lerna": "^3.22.1",
+    "json": "^11.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/ipfs-unixfs-exporter/package.json
+++ b/packages/ipfs-unixfs-exporter/package.json
@@ -12,6 +12,7 @@
     "prepare": "aegir build --no-bundle",
     "test": "aegir test",
     "build": "aegir build --esm-tests",
+    "postbuild": "npx json -I -f dist/package.json -e this.types='\"src/index.d.ts\"'",
     "clean": "rimraf ./dist",
     "lint": "aegir ts -p check && aegir lint",
     "coverage": "nyc -s npm run test -t node && nyc report --reporter=html",

--- a/packages/ipfs-unixfs-importer/package.json
+++ b/packages/ipfs-unixfs-importer/package.json
@@ -12,6 +12,7 @@
     "prepare": "aegir build --no-bundle",
     "test": "aegir test",
     "build": "aegir build --esm-tests",
+    "postbuild": "npx json -I -f dist/package.json -e this.types='\"src/index.d.ts\"'",
     "clean": "rimraf ./dist",
     "lint": "aegir ts -p check && aegir lint",
     "coverage": "nyc -s npm run test -t node && nyc report --reporter=html",

--- a/packages/ipfs-unixfs/package.json
+++ b/packages/ipfs-unixfs/package.json
@@ -15,6 +15,7 @@
     "prepare:types": "aegir build --no-bundle",
     "test": "aegir test",
     "build": "aegir build --esm-tests",
+    "postbuild": "npx json -I -f dist/package.json -e this.types='\"src/index.d.ts\"'",
     "clean": "rimraf ./dist",
     "lint": "aegir ts -p check && aegir lint",
     "coverage": "nyc -s aegir test -t node && nyc report --reporter=html",


### PR DESCRIPTION
Currently, the published package.json has `"types": "dist/src/index.d.ts"` and should be `"types": "src/index.d.ts",` according to where the types really are.

The problem here is that we need to both:
- have type paths correct in the dist folder
- have type paths correct for local dev in src

Given the path will change, we need to guarantee this is updated in the build `package.json`. Using an approach like `multiformats` and `uint8arrays` having a `types` folder which is moved to `dist` is not possible because of the inline `d.ts` files in this repo, which will be inside `dist` folder as `dist/src/*.d.ts`, breaking the imports from the types around it.

With the above in mind, this PR adds a postbuild script where the package.json is changed in post build to have `dist` removed.