### PR TITLE
fix: individual packages can use npm 6

### DIFF
--- a/packages/ipfs-unixfs-exporter/package.json
+++ b/packages/ipfs-unixfs-exporter/package.json
@@ -32,7 +32,7 @@
   },
   "engines": {
     "node": ">=14.0.0",
-    "npm": ">=7.0.0"
+    "npm": ">=6.0.0"
   },
   "homepage": "https://github.com/ipfs/js-ipfs-unixfs#readme",
   "publishConfig": {

--- a/packages/ipfs-unixfs-importer/package.json
+++ b/packages/ipfs-unixfs-importer/package.json
@@ -32,7 +32,7 @@
   },
   "engines": {
     "node": ">=14.0.0",
-    "npm": ">=7.0.0"
+    "npm": ">=6.0.0"
   },
   "homepage": "https://github.com/ipfs/js-ipfs-unixfs#readme",
   "publishConfig": {

--- a/packages/ipfs-unixfs/package.json
+++ b/packages/ipfs-unixfs/package.json
@@ -33,7 +33,7 @@
   },
   "engines": {
     "node": ">=14.0.0",
-    "npm": ">=7.0.0"
+    "npm": ">=6.0.0"
   },
   "homepage": "https://github.com/ipfs/js-ipfs-unixfs#readme",
   "publishConfig": {


### PR DESCRIPTION
We have engines with npm7 because we use npm7 workspaces, but this should only be needed in the main package.json for development. Internal packages should be published as supporting npm6 given that there are linux environments that still do not support npm7. For more information see https://github.com/web3-storage/web3.storage/issues/387 where this issue was raised

Closes https://github.com/web3-storage/web3.storage/issues/387