### PR TITLE
fix: don't split paths on `^` characters

### DIFF
--- a/packages/ipfs-unixfs-importer/src/utils/to-path-components.js
+++ b/packages/ipfs-unixfs-importer/src/utils/to-path-components.js
@@ -2,7 +2,7 @@ const toPathComponents = (path = '') => {
   // split on / unless escaped with \
   return (path
     .trim()
-    .match(/([^\\^/]|\\\/)+/g) || [])
+    .match(/([^\\/]|\\\/)+/g) || [])
     .filter(Boolean)
 }
 

--- a/packages/ipfs-unixfs-importer/test/utils.spec.js
+++ b/packages/ipfs-unixfs-importer/test/utils.spec.js
@@ -4,22 +4,22 @@ import { expect } from 'aegir/utils/chai.js'
 import toPathComponents from '../src/utils/to-path-components.js'
 
 describe('toPathComponents', () => {
-    it('splits on unescaped "/" characters', () => {
-        const path = 'foo/bar/baz'
-        const components = toPathComponents(path)
-        expect(components.length).to.eq(3)
-    })
+  it('splits on unescaped "/" characters', () => {
+    const path = 'foo/bar/baz'
+    const components = toPathComponents(path)
+    expect(components.length).to.eq(3)
+  })
 
-    it('does not split on escaped "/" characters', () => {
-        const path = 'foo\\/bar/baz'
-        const components = toPathComponents(path)
-        expect(components.length).to.eq(2)
-    })
+  it('does not split on escaped "/" characters', () => {
+    const path = 'foo\\/bar/baz'
+    const components = toPathComponents(path)
+    expect(components.length).to.eq(2)
+  })
 
-    // see https://github.com/ipfs/js-ipfs-unixfs/issues/177 for context
-    it('does not split on "^" characters', () => {
-        const path = 'foo/bar^baz^^qux'
-        const components = toPathComponents(path)
-        expect(components.length).to.eq(2)
-    })
+  // see https://github.com/ipfs/js-ipfs-unixfs/issues/177 for context
+  it('does not split on "^" characters', () => {
+    const path = 'foo/bar^baz^^qux'
+    const components = toPathComponents(path)
+    expect(components.length).to.eq(2)
+  })
 })

--- a/packages/ipfs-unixfs-importer/test/utils.spec.js
+++ b/packages/ipfs-unixfs-importer/test/utils.spec.js
@@ -1,0 +1,25 @@
+/* eslint-env mocha */
+
+import { expect } from 'aegir/utils/chai.js'
+import toPathComponents from '../src/utils/to-path-components.js'
+
+describe('toPathComponents', () => {
+    it('splits on unescaped "/" characters', () => {
+        const path = 'foo/bar/baz'
+        const components = toPathComponents(path)
+        expect(components.length).to.eq(3)
+    })
+
+    it('does not split on escaped "/" characters', () => {
+        const path = 'foo\\/bar/baz'
+        const components = toPathComponents(path)
+        expect(components.length).to.eq(2)
+    })
+
+    // see https://github.com/ipfs/js-ipfs-unixfs/issues/177 for context
+    it('does not split on "^" characters', () => {
+        const path = 'foo/bar^baz^^qux'
+        const components = toPathComponents(path)
+        expect(components.length).to.eq(2)
+    })
+})


### PR DESCRIPTION
This removes the extra `^` char from [this regex](https://github.com/ipfs/js-ipfs-unixfs/blob/master/packages/ipfs-unixfs-importer/src/utils/to-path-components.js#L5) that was causing us to treat the `^` as a path separator.

Closes #177, and will fix https://github.com/web3-storage/web3.storage/issues/375 when pulled into the web3.storage client.