### PR TITLE
fix: do not add metadata to leaves

### DIFF
--- a/packages/ipfs-unixfs-importer/src/dag-builder/file/buffer-importer.js
+++ b/packages/ipfs-unixfs-importer/src/dag-builder/file/buffer-importer.js
@@ -30,9 +30,7 @@ async function * bufferImporter (file, block, options) {
       } else {
         unixfs = new UnixFS({
           type: options.leafType,
-          data: buffer,
-          mtime: file.mtime,
-          mode: file.mode
+          data: buffer
         })
 
         buffer = dagPb.encode({


### PR DESCRIPTION
When an imported file is big enough to need leaf nodes, and that
file is imported with metadata, we should only add that metadata
to the root of the file DAG and not to every leaf in the graph.