### PR TITLE
fix: metadata on small files without raw leaves

### DIFF
--- a/packages/ipfs-unixfs-exporter/test/importer.spec.js
+++ b/packages/ipfs-unixfs-exporter/test/importer.spec.js
@@ -1073,6 +1073,24 @@ strategies.forEach((strategy) => {
       expect(child).to.have.property('unixfs')
       expect(child).to.not.have.nested.property('unixfs.mtime')
     })
+
+    it('should add metadata to the root node of a small file without raw leaves', async () => {
+      this.timeout(60 * 1000)
+
+      const mode = 511
+
+      const entries = await all(importer([{
+        path: '/foo/file1.txt',
+        content: asAsyncIterable(smallFile),
+        mode
+      }], block, {
+        rawLeaves: false
+      }))
+
+      const root = await exporter(entries[0].cid, block)
+
+      expect(root).to.have.nested.property('unixfs.mode', 511)
+    })
   })
 })
 

--- a/packages/ipfs-unixfs-importer/src/dag-builder/file/index.js
+++ b/packages/ipfs-unixfs-importer/src/dag-builder/file/index.js
@@ -78,7 +78,7 @@ const reduce = (file, blockstore, options) => {
     if (leaves.length === 1 && leaves[0].single && options.reduceSingleLeafToSelf) {
       const leaf = leaves[0]
 
-      if (leaf.cid.code === rawCodec.code && (file.mtime !== undefined || file.mode !== undefined)) {
+      if (file.mtime !== undefined || file.mode !== undefined) {
         // only one leaf node which is a buffer - we have metadata so convert it into a
         // UnixFS entry otherwise we'll have nowhere to store the metadata
         let buffer = await blockstore.get(leaf.cid)


### PR DESCRIPTION
A file with metadata and without raw leaves should have the metadata preserved when the single leaf node is collapse to a root node.