### PR TITLE
fix: remove typesVersions from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "private": true,
   "scripts": {
-    "reset": "lerna run clean && rimraf ./node_modules ./package-lock.json packages/*/node_modules packages/*/package-lock.json packages/*/dist",
+    "reset": "lerna run clean && rimraf ./node_modules ./package-lock.json packages/*/node_modules packages/*/package-lock.json",
     "test": "lerna run --concurrency 1 test -- --",
     "test:node": "lerna run --concurrency 1 test:node -- --",
     "test:chrome": "lerna run --concurrency 1 test:chrome -- --",
@@ -26,6 +26,7 @@
     "test:firefox-webworker": "lerna run --concurrency 1 test:firefox-webworker -- --",
     "test:electron-main": "lerna run --concurrency 1 test:electron-main -- --",
     "test:electron-renderer": "lerna run --concurrency 1 test:electron-renderer -- --",
+    "clean": "lerna run clean",
     "build": "lerna run build",
     "lint": "lerna run lint",
     "dep-check": "lerna run dep-check",

--- a/packages/ipfs-unixfs-exporter/package.json
+++ b/packages/ipfs-unixfs-exporter/package.json
@@ -20,18 +20,6 @@
   },
   "type": "module",
   "types": "types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "types/*",
-        "types/src/*"
-      ],
-      "types/*": [
-        "types/*",
-        "types/src/*"
-      ]
-    }
-  },
   "files": [
     "*",
     "!**/*.tsbuildinfo",
@@ -144,7 +132,7 @@
     "test:firefox": "aegir test -t browser -- --browser firefox",
     "build": "aegir build && cp -R types dist",
     "preleaseOnly": "npx json -I -f dist/package.json -e this.types='\"src/index.d.ts\"'",
-    "clean": "rimraf ./dist",
+    "clean": "rimraf ./dist ./types",
     "lint": "aegir ts -p check && aegir lint",
     "coverage": "nyc -s npm run test -t node && nyc report --reporter=html",
     "dep-check": "aegir dep-check -i @types/mocha -i @types/sinon -i nyc -i abort-controller -i rimraf -i copy -i util -i crypto-browserify -i events -i readable-stream -i interface-blockstore",

--- a/packages/ipfs-unixfs-importer/package.json
+++ b/packages/ipfs-unixfs-importer/package.json
@@ -20,18 +20,6 @@
   },
   "type": "module",
   "types": "types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "types/*",
-        "types/src/*"
-      ],
-      "types/*": [
-        "types/*",
-        "types/src/*"
-      ]
-    }
-  },
   "files": [
     "*",
     "!**/*.tsbuildinfo",
@@ -144,7 +132,7 @@
     "test:firefox": "aegir test -t browser -- --browser firefox",
     "build": "aegir build && cp -R types dist",
     "preleaseOnly": "npx json -I -f dist/package.json -e this.types='\"src/index.d.ts\"'",
-    "clean": "rimraf ./dist",
+    "clean": "rimraf ./dist ./types",
     "lint": "aegir ts -p check && aegir lint",
     "coverage": "nyc -s npm run test -t node && nyc report --reporter=html",
     "de-pcheck": "aegir dep-check -i @types/mocha -i nyc -i rimraf -i copy -i util -i crypto-browserify -i events -i readable-stream -i assert",

--- a/packages/ipfs-unixfs/package.json
+++ b/packages/ipfs-unixfs/package.json
@@ -20,18 +20,6 @@
   },
   "type": "module",
   "types": "types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "types/*",
-        "types/src/*"
-      ],
-      "types/*": [
-        "types/*",
-        "types/src/*"
-      ]
-    }
-  },
   "files": [
     "*",
     "!**/*.tsbuildinfo",
@@ -148,7 +136,7 @@
     "test:chrome": "aegir test -t browser --cov",
     "test:firefox": "aegir test -t browser -- --browser firefox",
     "build": "aegir build && cp -R types dist",
-    "clean": "rimraf ./dist",
+    "clean": "rimraf ./dist ./types",
     "lint": "aegir ts -p check && aegir lint",
     "coverage": "nyc -s aegir test -t node && nyc report --reporter=html",
     "dep-check": "aegir dep-check -i mkdirp -i @types/mocha -i nyc -i npm-run-all -i copy -i util",


### PR DESCRIPTION
We have `typesVersions` to allow deep requires from these modules, but
they cause incorrect paths to be detected by tsc (see #214).

Since #161 we control exports using the exports map, and we only export
the root from each module so deep requires are disallowed and consequently
`typesVersions` isn't necessary.

Since it's causing problems and we don't need it, remove it.  We can
revisit once we publish ESM-only but right now this fixes up the types
tsc generates.

Fixes #214