### PR TITLE
chore: update dep-check command

### DIFF
--- a/packages/ipfs-unixfs-exporter/package.json
+++ b/packages/ipfs-unixfs-exporter/package.json
@@ -146,8 +146,7 @@
     "preleaseOnly": "npx json -I -f dist/package.json -e this.types='\"src/index.d.ts\"'",
     "clean": "rimraf ./dist",
     "lint": "aegir ts -p check && aegir lint",
-    "coverage": "nyc -s npm run test -t node && nyc report --reporter=html",
-    "dep-check": "aegir dep-check -i @types/mocha -i @types/sinon -i nyc -i abort-controller -i rimraf -i copy -i util -i crypto-browserify -i events -i readable-stream -i interface-blockstore",
+    "dep-check": "aegir dep-check -i @types/sinon -i nyc -i rimraf -i copy -i util -i crypto-browserify -i events -i readable-stream -i interface-blockstore",
     "release": "semantic-release"
   },
   "dependencies": {
@@ -176,7 +175,6 @@
     "it-first": "^1.0.6",
     "merge-options": "^3.0.4",
     "native-abort-controller": "^1.0.3",
-    "nyc": "^15.0.0",
     "readable-stream": "^3.6.0",
     "rimraf": "^3.0.2",
     "sinon": "^14.0.0",

--- a/packages/ipfs-unixfs-importer/package.json
+++ b/packages/ipfs-unixfs-importer/package.json
@@ -146,8 +146,7 @@
     "preleaseOnly": "npx json -I -f dist/package.json -e this.types='\"src/index.d.ts\"'",
     "clean": "rimraf ./dist",
     "lint": "aegir ts -p check && aegir lint",
-    "coverage": "nyc -s npm run test -t node && nyc report --reporter=html",
-    "de-pcheck": "aegir dep-check -i @types/mocha -i nyc -i rimraf -i copy -i util -i crypto-browserify -i events -i readable-stream -i assert -i interface-blockstore",
+    "dep-check": "aegir dep-check -i rimraf -i copy -i util -i crypto-browserify -i events -i readable-stream -i assert -i interface-blockstore",
     "release": "semantic-release"
   },
   "dependencies": {
@@ -175,7 +174,6 @@
     "crypto-browserify": "^3.12.0",
     "events": "^3.3.0",
     "it-buffer-stream": "^2.0.0",
-    "nyc": "^15.0.0",
     "readable-stream": "^3.6.0",
     "rimraf": "^3.0.2",
     "util": "^0.12.3",

--- a/packages/ipfs-unixfs/package.json
+++ b/packages/ipfs-unixfs/package.json
@@ -150,8 +150,7 @@
     "build": "aegir build && cp -R types dist",
     "clean": "rimraf ./dist",
     "lint": "aegir ts -p check && aegir lint",
-    "coverage": "nyc -s aegir test -t node && nyc report --reporter=html",
-    "dep-check": "aegir dep-check -i mkdirp -i @types/mocha -i nyc -i npm-run-all -i copy -i util",
+    "dep-check": "aegir dep-check -i mkdirp -i npm-run-all -i copy -i util",
     "release": "semantic-release"
   },
   "dependencies": {
@@ -163,7 +162,6 @@
     "copy": "^0.3.2",
     "mkdirp": "^1.0.4",
     "npm-run-all": "^4.1.5",
-    "nyc": "^15.0.0",
     "uint8arrays": "^3.0.0",
     "util": "^0.12.3"
   },


### PR DESCRIPTION
Also removes coverage with nyc because we use `--cov` with aegir instead.