### PR TITLE
fix: parallelise loading of dag-pb links when exporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ logs
 *.log
 
 coverage
+.coverage
 *.lcov
 
 # Runtime data

--- a/packages/ipfs-unixfs-exporter/package.json
+++ b/packages/ipfs-unixfs-exporter/package.json
@@ -159,6 +159,10 @@
     "interface-blockstore": "^3.0.0",
     "ipfs-unixfs": "^7.0.0",
     "it-last": "^1.0.5",
+    "it-parallel": "^2.0.1",
+    "it-pipe": "^2.0.4",
+    "it-pushable": "^3.1.0",
+    "it-map": "^1.0.6",
     "multiformats": "^9.4.2",
     "uint8arrays": "^3.0.0"
   },
@@ -168,6 +172,7 @@
     "aegir": "^37.5.0",
     "blockstore-core": "^2.0.1",
     "crypto-browserify": "^3.12.0",
+    "delay": "^5.0.0",
     "ipfs-unixfs-importer": "^10.0.0",
     "it-all": "^1.0.5",
     "it-buffer-stream": "^2.0.0",

--- a/packages/ipfs-unixfs-exporter/src/resolvers/unixfs-v1/content/file.js
+++ b/packages/ipfs-unixfs-exporter/src/resolvers/unixfs-v1/content/file.js
@@ -4,38 +4,41 @@ import { UnixFS } from 'ipfs-unixfs'
 import errCode from 'err-code'
 import * as dagPb from '@ipld/dag-pb'
 import * as raw from 'multiformats/codecs/raw'
+import { pushable } from 'it-pushable'
+import parallel from 'it-parallel'
+import { pipe } from 'it-pipe'
+import map from 'it-map'
 
 /**
  * @typedef {import('../../../types').ExporterOptions} ExporterOptions
  * @typedef {import('interface-blockstore').Blockstore} Blockstore
  * @typedef {import('@ipld/dag-pb').PBNode} PBNode
- *
+ * @typedef {import('@ipld/dag-pb').PBLink} PBLink
+ */
+
+/**
  * @param {Blockstore} blockstore
  * @param {PBNode | Uint8Array} node
+ * @param {import('it-pushable').Pushable<Uint8Array | undefined>} queue
+ * @param {number} streamPosition
  * @param {number} start
  * @param {number} end
- * @param {number} streamPosition
  * @param {ExporterOptions} options
- * @returns {AsyncIterable<Uint8Array>}
+ * @returns {Promise<void>}
  */
-async function * emitBytes (blockstore, node, start, end, streamPosition = 0, options) {
+async function walkDAG (blockstore, node, queue, streamPosition, start, end, options) {
   // a `raw` node
   if (node instanceof Uint8Array) {
-    const buf = extractDataFromBlock(node, streamPosition, start, end)
+    queue.push(extractDataFromBlock(node, streamPosition, start, end))
 
-    if (buf.length) {
-      yield buf
-    }
-
-    streamPosition += buf.length
-
-    return streamPosition
+    return
   }
 
   if (node.Data == null) {
     throw errCode(new Error('no data in PBNode'), 'ERR_NOT_UNIXFS')
   }
 
+  /** @type {UnixFS} */
   let file
 
   try {
@@ -45,51 +48,74 @@ async function * emitBytes (blockstore, node, start, end, streamPosition = 0, op
   }
 
   // might be a unixfs `raw` node or have data on intermediate nodes
-  if (file.data && file.data.length) {
-    const buf = extractDataFromBlock(file.data, streamPosition, start, end)
+  if (file.data != null) {
+    const data = file.data
+    const buf = extractDataFromBlock(data, streamPosition, start, end)
 
-    if (buf.length) {
-      yield buf
-    }
+    queue.push(buf)
 
-    streamPosition += file.data.length
+    streamPosition += buf.byteLength
   }
 
-  let childStart = streamPosition
+  /** @type {Array<{ link: PBLink, blockStart: number }>} */
+  const childOps = []
 
-  // work out which child nodes contain the requested data
   for (let i = 0; i < node.Links.length; i++) {
     const childLink = node.Links[i]
-    const childEnd = streamPosition + file.blockSizes[i]
+    const childStart = streamPosition // inclusive
+    const childEnd = childStart + file.blockSizes[i] // exclusive
 
     if ((start >= childStart && start < childEnd) || // child has offset byte
-        (end > childStart && end <= childEnd) || // child has end byte
+        (end >= childStart && end <= childEnd) || // child has end byte
         (start < childStart && end > childEnd)) { // child is between offset and end bytes
-      const block = await blockstore.get(childLink.Hash, {
-        signal: options.signal
+      childOps.push({
+        link: childLink,
+        blockStart: streamPosition
       })
-      let child
-      switch (childLink.Hash.code) {
-        case dagPb.code:
-          child = await dagPb.decode(block)
-          break
-        case raw.code:
-          child = block
-          break
-        default:
-          throw Error(`Unsupported codec: ${childLink.Hash.code}`)
-      }
-
-      for await (const buf of emitBytes(blockstore, child, start, end, streamPosition, options)) {
-        streamPosition += buf.length
-
-        yield buf
-      }
     }
 
     streamPosition = childEnd
-    childStart = childEnd + 1
+
+    if (streamPosition > end) {
+      break
+    }
   }
+
+  await pipe(
+    childOps,
+    (source) => map(source, (op) => {
+      return async () => {
+        const block = await blockstore.get(op.link.Hash, {
+          signal: options.signal
+        })
+
+        return {
+          ...op,
+          block
+        }
+      }
+    }),
+    (source) => parallel(source, {
+      ordered: true
+    }),
+    async (source) => {
+      for await (const { link, block, blockStart } of source) {
+        let child
+        switch (link.Hash.code) {
+          case dagPb.code:
+            child = await dagPb.decode(block)
+            break
+          case raw.code:
+            child = block
+            break
+          default:
+            throw errCode(new Error(`Unsupported codec: ${link.Hash.code}`), 'ERR_NOT_UNIXFS')
+        }
+
+        await walkDAG(blockstore, child, queue, blockStart, start, end, options)
+      }
+    }
+  )
 }
 
 /**
@@ -99,7 +125,7 @@ const fileContent = (cid, node, unixfs, path, resolve, depth, blockstore) => {
   /**
    * @param {ExporterOptions} options
    */
-  function yieldFileContent (options = {}) {
+  async function * yieldFileContent (options = {}) {
     const fileSize = unixfs.fileSize()
 
     if (fileSize === undefined) {
@@ -111,10 +137,28 @@ const fileContent = (cid, node, unixfs, path, resolve, depth, blockstore) => {
       length
     } = validateOffsetAndLength(fileSize, options.offset, options.length)
 
-    const start = offset
-    const end = offset + length
+    const queue = pushable({
+      objectMode: true
+    })
 
-    return emitBytes(blockstore, node, start, end, 0, options)
+    walkDAG(blockstore, node, queue, 0, offset, offset + length, options)
+      .catch(err => {
+        queue.end(err)
+      })
+
+    let read = 0
+
+    for await (const buf of queue) {
+      if (buf != null) {
+        yield buf
+
+        read += buf.byteLength
+
+        if (read === length) {
+          queue.end()
+        }
+      }
+    }
   }
 
   return yieldFileContent

--- a/packages/ipfs-unixfs-exporter/src/resolvers/unixfs-v1/content/file.js
+++ b/packages/ipfs-unixfs-exporter/src/resolvers/unixfs-v1/content/file.js
@@ -3,7 +3,6 @@ import validateOffsetAndLength from '../../../utils/validate-offset-and-length.j
 import { UnixFS } from 'ipfs-unixfs'
 import errCode from 'err-code'
 import * as dagPb from '@ipld/dag-pb'
-import * as dagCbor from '@ipld/dag-cbor'
 import * as raw from 'multiformats/codecs/raw'
 
 /**
@@ -12,7 +11,7 @@ import * as raw from 'multiformats/codecs/raw'
  * @typedef {import('@ipld/dag-pb').PBNode} PBNode
  *
  * @param {Blockstore} blockstore
- * @param {PBNode} node
+ * @param {PBNode | Uint8Array} node
  * @param {number} start
  * @param {number} end
  * @param {number} streamPosition
@@ -76,9 +75,6 @@ async function * emitBytes (blockstore, node, start, end, streamPosition = 0, op
           break
         case raw.code:
           child = block
-          break
-        case dagCbor.code:
-          child = await dagCbor.decode(block)
           break
         default:
           throw Error(`Unsupported codec: ${childLink.Hash.code}`)

--- a/packages/ipfs-unixfs-exporter/src/utils/extract-data-from-block.js
+++ b/packages/ipfs-unixfs-exporter/src/utils/extract-data-from-block.js
@@ -16,12 +16,12 @@ function extractDataFromBlock (block, blockStart, requestedStart, requestedEnd) 
 
   if (requestedEnd >= blockStart && requestedEnd < blockEnd) {
     // If the end byte is in the current block, truncate the block to the end byte
-    block = block.slice(0, requestedEnd - blockStart)
+    block = block.subarray(0, requestedEnd - blockStart)
   }
 
   if (requestedStart >= blockStart && requestedStart < blockEnd) {
     // If the start byte is in the current block, skip to the start byte
-    block = block.slice(requestedStart - blockStart)
+    block = block.subarray(requestedStart - blockStart)
   }
 
   return block


### PR DESCRIPTION
A polishing of #237.  Uses `it-parallel` to load a whole list of children of a DAG node in parallel rather than one at a time.  Makes fetching large files much faster.

From the js-ipfs interop suite:

Before:

```console
  exchange files
    go -> js
      cat file
        ✔ go -> js: 67.1 MB (25659ms)
    go -> go2
      cat file
        ✔ go -> go2: 67.1 MB (19835ms)
    js -> go
      cat file
        ✔ js -> go: 67.1 MB (17407ms)
    js -> js2
      cat file
        ✔ js -> js2: 67.1 MB (20237ms)
```

After:

```console
  exchange files
    go -> js
      cat file
        ✔ go -> js: 67.1 MB (15328ms)
    go -> go2
      cat file
        ✔ go -> go2: 67.1 MB (18536ms)
    js -> go
      cat file
        ✔ js -> go: 67.1 MB (17211ms)
    js -> js2
      cat file
        ✔ js -> js2: 67.1 MB (12124ms)
```