### PR TITLE
fix: specify return type of the importer to generate correct types

### DIFF
--- a/packages/ipfs-unixfs-exporter/src/types.ts
+++ b/packages/ipfs-unixfs-exporter/src/types.ts
@@ -2,6 +2,7 @@ import type { CID } from 'multiformats/cid'
 import type { UnixFS } from 'ipfs-unixfs'
 import type { PBNode } from '@ipld/dag-pb'
 import type { Blockstore } from 'interface-blockstore'
+import type { Bucket } from 'hamt-sharding'
 
 export interface ExporterOptions {
   offset?: number
@@ -68,3 +69,9 @@ export type UnixfsV1FileContent = AsyncIterable<Uint8Array> | Iterable<Uint8Arra
 export type UnixfsV1DirectoryContent = AsyncIterable<UnixFSEntry> | Iterable<UnixFSEntry>
 export type UnixfsV1Content = UnixfsV1FileContent | UnixfsV1DirectoryContent
 export interface UnixfsV1Resolver { (cid: CID, node: PBNode, unixfs: UnixFS, path: string, resolve: Resolve, depth: number, blockstore: Blockstore): (options: ExporterOptions) => UnixfsV1Content }
+
+export interface ShardTraversalContext {
+  hamtDepth: number
+  rootBucket: Bucket<boolean>
+  lastBucket: Bucket<boolean>
+}

--- a/packages/ipfs-unixfs-exporter/src/utils/find-cid-in-shard.js
+++ b/packages/ipfs-unixfs-exporter/src/utils/find-cid-in-shard.js
@@ -81,10 +81,7 @@ const toBucketPath = (position) => {
 }
 
 /**
- * @typedef {object} ShardTraversalContext
- * @property {number} hamtDepth
- * @property {Bucket<boolean>} rootBucket
- * @property {Bucket<boolean>} lastBucket
+ * @typedef {import('../types').ShardTraversalContext} ShardTraversalContext
  *
  * @param {PBNode} node
  * @param {string} name

--- a/packages/ipfs-unixfs-importer/src/index.js
+++ b/packages/ipfs-unixfs-importer/src/index.js
@@ -25,6 +25,7 @@ import treeBuilderFn from './tree-builder.js'
  * @param {AsyncIterable<ImportCandidate> | Iterable<ImportCandidate> | ImportCandidate} source
  * @param {Blockstore} blockstore
  * @param {UserImporterOptions} options
+ * @returns {AsyncGenerator<ImportResult, void, unknown>}
  */
 export async function * importer (source, blockstore, options = {}) {
   const opts = defaultOptions(options)


### PR DESCRIPTION
If we don't to this, we end up importing deep paths from `unixfs` in the generated types which aren't in the exports map so fail when people are compiling their dependencies.

Fixes #214