### PR TITLE
fix: prevent OOM on very deep DAGs

### DIFF
--- a/packages/ipfs-unixfs-exporter/package.json
+++ b/packages/ipfs-unixfs-exporter/package.json
@@ -163,6 +163,7 @@
     "it-pipe": "^2.0.4",
     "it-pushable": "^3.1.0",
     "it-map": "^1.0.6",
+    "p-queue": "^7.3.0",
     "multiformats": "^9.4.2",
     "uint8arrays": "^3.0.0"
   },


### PR DESCRIPTION
Refactor exporting files to use a queue instead of recursion to walk the DAG.  The queue exectutes on a new stack so we won't run out of memory when traversing very deep DAGs.