### PR TITLE
fix: parallelise loading of dag-pb links in directories when exporting

### DIFF
--- a/packages/ipfs-unixfs-exporter/package.json
+++ b/packages/ipfs-unixfs-exporter/package.json
@@ -142,6 +142,7 @@
     "hamt-sharding": "^3.0.0",
     "interface-blockstore": "^4.0.0",
     "ipfs-unixfs": "^11.0.0",
+    "it-filter": "^2.0.0",
     "it-last": "^2.0.0",
     "it-map": "^2.0.0",
     "it-parallel": "^3.0.0",

--- a/packages/ipfs-unixfs-exporter/src/resolvers/unixfs-v1/content/hamt-sharded-directory.ts
+++ b/packages/ipfs-unixfs-exporter/src/resolvers/unixfs-v1/content/hamt-sharded-directory.ts
@@ -1,3 +1,6 @@
+import parallel from 'it-parallel'
+import { pipe } from 'it-pipe'
+import map from 'it-map'
 import { decode, PBNode } from '@ipld/dag-pb'
 import type { Blockstore } from 'interface-blockstore'
 import type { ExporterOptions, Resolve, UnixfsV1DirectoryContent, UnixfsV1Resolver } from '../../../index.js'
@@ -22,22 +25,30 @@ const hamtShardedDirectoryContent: UnixfsV1Resolver = (cid, node, unixfs, path, 
 async function * listDirectory (node: PBNode, path: string, resolve: Resolve, depth: number, blockstore: Blockstore, options: ExporterOptions): UnixfsV1DirectoryContent {
   const links = node.Links
 
-  for (const link of links) {
-    const name = link.Name != null ? link.Name.substring(2) : null
+  const results = pipe(
+    links,
+    source => map(source, link => {
+      return async () => {
+        const name = link.Name != null ? link.Name.substring(2) : null
 
-    if (name != null && name !== '') {
-      const result = await resolve(link.Hash, name, `${path}/${name}`, [], depth + 1, blockstore, options)
+        if (name != null && name !== '') {
+          const result = await resolve(link.Hash, name, `${path}/${name}`, [], depth + 1, blockstore, options)
 
-      yield result.entry
-    } else {
-      // descend into subshard
-      const block = await blockstore.get(link.Hash)
-      node = decode(block)
+          return { entries: result.entry == null ? [] : [result.entry] }
+        } else {
+          // descend into subshard
+          const block = await blockstore.get(link.Hash)
+          node = decode(block)
 
-      for await (const file of listDirectory(node, path, resolve, depth, blockstore, options)) {
-        yield file
+          return { entries: listDirectory(node, path, resolve, depth, blockstore, options) }
+        }
       }
-    }
+    }),
+    source => parallel(source, { ordered: true })
+  )
+
+  for await (const { entries } of results) {
+    yield * entries
   }
 }
 


### PR DESCRIPTION
This PR extends the work done in https://github.com/ipfs/js-ipfs-unixfs/pull/249 to also include directories and sharded directories.