### PR TITLE
deps!: update blockstore

### DIFF
--- a/packages/ipfs-unixfs-exporter/package.json
+++ b/packages/ipfs-unixfs-exporter/package.json
@@ -140,7 +140,7 @@
     "@multiformats/murmur3": "^2.0.0",
     "err-code": "^3.0.1",
     "hamt-sharding": "^3.0.0",
-    "interface-blockstore": "^4.0.1",
+    "interface-blockstore": "^5.0.0",
     "ipfs-unixfs": "^11.0.0",
     "it-filter": "^2.0.0",
     "it-last": "^2.0.0",
@@ -155,7 +155,7 @@
   "devDependencies": {
     "@types/sinon": "^10.0.0",
     "aegir": "^38.1.2",
-    "blockstore-core": "^3.0.0",
+    "blockstore-core": "^4.0.1",
     "delay": "^5.0.0",
     "ipfs-unixfs-importer": "^14.0.0",
     "it-all": "^2.0.0",

--- a/packages/ipfs-unixfs-importer/package.json
+++ b/packages/ipfs-unixfs-importer/package.json
@@ -164,7 +164,8 @@
     "err-code": "^3.0.1",
     "hamt-sharding": "^3.0.0",
     "ipfs-unixfs": "^11.0.0",
-    "interface-blockstore": "^4.0.1",
+    "interface-blockstore": "^5.0.0",
+    "interface-store": "^4.0.0",
     "it-all": "^2.0.0",
     "it-batch": "^2.0.0",
     "it-first": "^2.0.0",
@@ -176,7 +177,7 @@
   },
   "devDependencies": {
     "aegir": "^38.1.2",
-    "blockstore-core": "^3.0.0",
+    "blockstore-core": "^4.0.1",
     "it-buffer-stream": "^3.0.0",
     "it-drain": "^2.0.0",
     "it-last": "^2.0.0",

--- a/packages/ipfs-unixfs-importer/src/index.ts
+++ b/packages/ipfs-unixfs-importer/src/index.ts
@@ -11,7 +11,7 @@ import { balanced, FileLayout } from './layout/index.js'
 import { defaultBufferImporter } from './dag-builder/buffer-importer.js'
 import first from 'it-first'
 import errcode from 'err-code'
-import type { AwaitIterable } from 'blockstore-core/base'
+import type { AwaitIterable } from 'interface-store'
 
 export type ByteStream = AwaitIterable<Uint8Array>
 export type ImportContent = ByteStream | Uint8Array


### PR DESCRIPTION
This is a breaking change because the return type of `interface-blockstore` methods can now be promises or simple values which can affects the type of blockstore object that is accepted by the importer/exporter - internally the results are `await`ed on but the difference in types can upset typescript in some cases so it's safer to release it as a major.

BREAKING CHANGE: please use the latest `interface-blockstore` versions of everything, aside from this impact should be minimal