### PR TITLE
fix: remove unused timeout option from exporter

### DIFF
--- a/packages/ipfs-unixfs-exporter/src/index.ts
+++ b/packages/ipfs-unixfs-exporter/src/index.ts
@@ -12,7 +12,6 @@ export interface ExporterOptions extends ProgressOptions {
   offset?: number
   length?: number
   signal?: AbortSignal
-  timeout?: number
 }
 
 export interface Exportable<T> {


### PR DESCRIPTION
This option is not used, pass an AbortSignal instead