### PR TITLE
fix: reduce required number of blockstore methods

### DIFF
--- a/packages/ipfs-unixfs-exporter/src/index.ts
+++ b/packages/ipfs-unixfs-exporter/src/index.ts
@@ -79,11 +79,7 @@ export interface ShardTraversalContext {
   lastBucket: Bucket<boolean>
 }
 
-export interface BlockstoreOptions {
-  signal?: AbortSignal
-}
-
-export type Blockstore = Pick<InterfaceBlockstore, 'has' | 'put' | 'get'>
+export type Blockstore = Pick<InterfaceBlockstore, 'get'>
 
 const toPathComponents = (path: string = ''): string[] => {
   // split on / unless escaped with \

--- a/packages/ipfs-unixfs-importer/src/dag-builder/dir.ts
+++ b/packages/ipfs-unixfs-importer/src/dag-builder/dir.ts
@@ -17,15 +17,16 @@ export const dirBuilder = async (dir: Directory, blockstore: Blockstore, options
     mode: dir.mode
   })
 
-  const buffer = encode(prepare({ Data: unixfs.marshal() }))
-  const cid = await persist(buffer, blockstore, options)
+  const block = encode(prepare({ Data: unixfs.marshal() }))
+  const cid = await persist(block, blockstore, options)
   const path = dir.path
 
   return {
     cid,
     path,
     unixfs,
-    size: BigInt(buffer.length),
-    originalPath: dir.originalPath
+    size: BigInt(block.length),
+    originalPath: dir.originalPath,
+    block
   }
 }

--- a/packages/ipfs-unixfs-importer/src/index.ts
+++ b/packages/ipfs-unixfs-importer/src/index.ts
@@ -17,11 +17,7 @@ import type { ProgressOptions } from 'progress-events'
 export type ByteStream = AwaitIterable<Uint8Array>
 export type ImportContent = ByteStream | Uint8Array
 
-export interface BlockstoreOptions {
-  signal?: AbortSignal
-}
-
-export type Blockstore = Pick<InterfaceBlockstore, 'has' | 'put' | 'get'>
+export type Blockstore = Pick<InterfaceBlockstore, 'put'>
 
 export interface FileCandidate {
   path?: string
@@ -60,14 +56,25 @@ export interface ImportResult {
   unixfs?: UnixFS
 }
 
-export interface InProgressImportResult extends ImportResult {
-  single?: boolean
+export interface MultipleBlockImportResult extends ImportResult {
   originalPath?: string
+}
+
+export interface SingleBlockImportResult extends ImportResult {
+  single: true
+  originalPath?: string
+  block: Uint8Array
+}
+
+export type InProgressImportResult = SingleBlockImportResult | MultipleBlockImportResult
+
+export interface BufferImporterResult extends ImportResult {
+  block: Uint8Array
 }
 
 export interface HamtHashFn { (value: Uint8Array): Promise<Uint8Array> }
 export interface TreeBuilder { (source: AsyncIterable<InProgressImportResult>, blockstore: Blockstore): AsyncIterable<ImportResult> }
-export interface BufferImporter { (file: File, blockstore: Blockstore): AsyncIterable<() => Promise<InProgressImportResult>> }
+export interface BufferImporter { (file: File, blockstore: Blockstore): AsyncIterable<() => Promise<BufferImporterResult>> }
 
 export type ImportProgressEvents =
   BufferImportProgressEvents

--- a/packages/ipfs-unixfs-importer/test/builder-balanced.spec.ts
+++ b/packages/ipfs-unixfs-importer/test/builder-balanced.spec.ts
@@ -24,7 +24,8 @@ describe('builder: balanced', () => {
   it('reduces one value into itself', async () => {
     const source = [{
       cid: CID.parse('QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn'),
-      size: 0n
+      size: 0n,
+      block: Uint8Array.from([])
     }]
 
     const result = await balanced(options)((async function * () {
@@ -37,13 +38,16 @@ describe('builder: balanced', () => {
   it('reduces 3 values into parent', async () => {
     const source = [{
       cid: CID.parse('QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn'),
-      size: 0n
+      size: 0n,
+      block: Uint8Array.from([])
     }, {
       cid: CID.parse('QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn'),
-      size: 0n
+      size: 0n,
+      block: Uint8Array.from([])
     }, {
       cid: CID.parse('QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn'),
-      size: 0n
+      size: 0n,
+      block: Uint8Array.from([])
     }]
 
     const result = await balanced(options)((async function * () {

--- a/packages/ipfs-unixfs-importer/test/chunker-custom.spec.ts
+++ b/packages/ipfs-unixfs-importer/test/chunker-custom.spec.ts
@@ -19,7 +19,7 @@ describe('custom chunker', function () {
   const block = new MemoryBlockstore()
 
   const fromPartsTest = (content: AsyncIterable<Uint8Array>, size: bigint) => async () => {
-    const put = async (buf: Uint8Array): Promise<{ cid: CID, size: bigint, unixfs: UnixFS }> => {
+    const put = async (buf: Uint8Array): Promise<{ cid: CID, size: bigint, unixfs: UnixFS, block: Uint8Array }> => {
       const encodedBlock = await Block.encode({
         value: buf,
         codec: rawCodec,
@@ -29,7 +29,8 @@ describe('custom chunker', function () {
       return {
         cid: encodedBlock.cid,
         size: BigInt(buf.length),
-        unixfs: new UnixFS()
+        unixfs: new UnixFS(),
+        block: buf
       }
     }
 


### PR DESCRIPTION
The importer only needs `.put`, the exporter only needs `.get`