### PR TITLE
docs: example in README of ipfs-unixfs-importer

### DIFF
--- a/packages/ipfs-unixfs-importer/README.md
+++ b/packages/ipfs-unixfs-importer/README.md
@@ -44,7 +44,7 @@ Let's create a little directory to import:
 > cd /tmp
 > mkdir foo
 > echo 'hello' > foo/bar
-> echo 'world' > foo/quux
+> echo 'world' > foo/quxx
 ```
 
 And write the importing logic:
@@ -52,20 +52,21 @@ And write the importing logic:
 ```js
 import { importer } from 'ipfs-unixfs-importer'
 import { MemoryBlockstore } from 'blockstore-core/memory'
+import * as fs from 'fs'
 
 // Where the blocks will be stored
 const blockstore = new MemoryBlockstore()
 
-// Import path /tmp/foo/bar
+// Import path /tmp/foo/
 const source = [{
   path: '/tmp/foo/bar',
-  content: fs.createReadStream(file)
+  content: fs.createReadStream('/tmp/foo/bar')
 }, {
   path: '/tmp/foo/quxx',
-  content: fs.createReadStream(file2)
+  content: fs.createReadStream('/tmp/foo/quxx')
 }]
 
-for await (const entry of importer(source, blockstore, options)) {
+for await (const entry of importer(source, blockstore)) {
   console.info(entry)
 }
 ```

--- a/packages/ipfs-unixfs-importer/README.md
+++ b/packages/ipfs-unixfs-importer/README.md
@@ -44,7 +44,7 @@ Let's create a little directory to import:
 > cd /tmp
 > mkdir foo
 > echo 'hello' > foo/bar
-> echo 'world' > foo/quxx
+> echo 'world' > foo/quux
 ```
 
 And write the importing logic:
@@ -52,7 +52,7 @@ And write the importing logic:
 ```js
 import { importer } from 'ipfs-unixfs-importer'
 import { MemoryBlockstore } from 'blockstore-core/memory'
-import * as fs from 'fs'
+import * as fs from 'node:fs'
 
 // Where the blocks will be stored
 const blockstore = new MemoryBlockstore()
@@ -63,7 +63,7 @@ const source = [{
   content: fs.createReadStream('/tmp/foo/bar')
 }, {
   path: '/tmp/foo/quxx',
-  content: fs.createReadStream('/tmp/foo/quxx')
+  content: fs.createReadStream('/tmp/foo/quux')
 }]
 
 for await (const entry of importer(source, blockstore)) {


### PR DESCRIPTION
* import `fs`
* remove undefined variables: `file`, `file2`, and `options`
* fix typo causing error "no such file or directory, open './foo/quxx'"