### PR TITLE
chore: add react native compat

### DIFF
--- a/packages/ipfs-unixfs-exporter/package.json
+++ b/packages/ipfs-unixfs-exporter/package.json
@@ -26,6 +26,11 @@
     "!dist/test",
     "!**/*.tsbuildinfo"
   ],
+  "react-native": {
+    "index": "./dist/src/index.js",
+    "fs": false,
+    "readable-stream": false
+  },
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",

--- a/packages/ipfs-unixfs-importer/package.json
+++ b/packages/ipfs-unixfs-importer/package.json
@@ -42,6 +42,10 @@
     "!dist/test",
     "!**/*.tsbuildinfo"
   ],
+  "react-native": {
+    "fs": false,
+    "index": "./dist/src/index.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",

--- a/packages/ipfs-unixfs/package.json
+++ b/packages/ipfs-unixfs/package.json
@@ -26,6 +26,10 @@
     "!dist/test",
     "!**/*.tsbuildinfo"
   ],
+  "react-native": {
+    "index": "./dist/src/index.js",
+    "fs": false
+  },
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",


### PR DESCRIPTION
emulating the no-ops from "browser" while providing an entrypoint