### PR TITLE
fix: add optional type for file candidate data

### DIFF
--- a/packages/ipfs-unixfs-importer/src/index.ts
+++ b/packages/ipfs-unixfs-importer/src/index.ts
@@ -20,9 +20,9 @@ export type ImportContent = ByteStream | Uint8Array
 
 export type WritableStorage = Pick<Blockstore, 'put'>
 
-export interface FileCandidate {
+export interface FileCandidate<T extends ImportContent = ImportContent> {
   path?: string
-  content: ImportContent
+  content: T
   mtime?: Mtime
   mode?: number
 }


### PR DESCRIPTION
Where we know the type of content to be imported ahead of time (e.g. a Uint8Array or a stream, not both), it can be helpful to specify that type, so make `FileCandidate` generic to allow this.

Defaults it to the previous `ImportContent` value so this is non-breaking.