### PR TITLE
fix(chunker-rabin): types and errors are aligned

### DIFF
--- a/packages/ipfs-unixfs-importer/src/chunker/rabin.ts
+++ b/packages/ipfs-unixfs-importer/src/chunker/rabin.ts
@@ -50,8 +50,14 @@ export const rabin = (options: RabinOptions = {}): Chunker => {
     max = avg + (avg / 2)
   }
 
-  if (options.avgChunkSize == null && options.minChunkSize == null && options.maxChunkSize == null) {
-    throw errcode(new Error('please specify an average chunk size'), 'ERR_INVALID_AVG_CHUNK_SIZE')
+  const isInvalidChunkSizes = [min, avg, max].some((size) => size == null || isNaN(size))
+
+  if (options.avgChunkSize != null && isInvalidChunkSizes) {
+    throw errcode(new Error('please specify a valid average chunk size number'), 'ERR_INVALID_AVG_CHUNK_SIZE')
+  }
+
+  if (isInvalidChunkSizes) {
+    throw errcode(new Error('please specify valid numbers for (min|max|avg)ChunkSize'), 'ERR_INVALID_CHUNK_SIZE')
   }
 
   // validate min/max/avg in the same way as go

--- a/packages/ipfs-unixfs-importer/src/chunker/rabin.ts
+++ b/packages/ipfs-unixfs-importer/src/chunker/rabin.ts
@@ -56,7 +56,7 @@ export const rabin = (options: RabinOptions = {}): Chunker => {
     if (options.avgChunkSize != null) {
       throw errcode(new Error('please specify a valid average chunk size number'), 'ERR_INVALID_AVG_CHUNK_SIZE')
     }
-    
+
     throw errcode(new Error('please specify valid numbers for (min|max|avg)ChunkSize'), 'ERR_INVALID_CHUNK_SIZE')
   }
 

--- a/packages/ipfs-unixfs-importer/src/chunker/rabin.ts
+++ b/packages/ipfs-unixfs-importer/src/chunker/rabin.ts
@@ -52,11 +52,11 @@ export const rabin = (options: RabinOptions = {}): Chunker => {
 
   const isInvalidChunkSizes = [min, avg, max].some((size) => size == null || isNaN(size))
 
-  if (options.avgChunkSize != null && isInvalidChunkSizes) {
-    throw errcode(new Error('please specify a valid average chunk size number'), 'ERR_INVALID_AVG_CHUNK_SIZE')
-  }
-
   if (isInvalidChunkSizes) {
+    if (options.avgChunkSize != null) {
+      throw errcode(new Error('please specify a valid average chunk size number'), 'ERR_INVALID_AVG_CHUNK_SIZE')
+    }
+    
     throw errcode(new Error('please specify valid numbers for (min|max|avg)ChunkSize'), 'ERR_INVALID_CHUNK_SIZE')
   }
 

--- a/packages/ipfs-unixfs-importer/test/chunker-rabin.spec.ts
+++ b/packages/ipfs-unixfs-importer/test/chunker-rabin.spec.ts
@@ -21,6 +21,10 @@ describe('chunker: rabin', function () {
     return
   }
 
+  it('Allows constructing without any options', () => {
+    expect(() => rabin()).to.not.throw()
+  })
+
   it('chunks non flat buffers', async () => {
     const b1 = new Uint8Array(2 * 256)
     const b2 = new Uint8Array(1 * 256)

--- a/packages/ipfs-unixfs-importer/test/chunker-rabin.spec.ts
+++ b/packages/ipfs-unixfs-importer/test/chunker-rabin.spec.ts
@@ -100,16 +100,45 @@ describe('chunker: rabin', function () {
     }
   })
 
-  it('throws when avg chunk size is not specified', async () => {
+  it('throws when invalid avg chunk size is specified', async () => {
     const opts = {
-      avgChunkSize: undefined
+      avgChunkSize: 'fortytwo'
     }
 
     try {
+      // @ts-expect-error invalid input
       await all(rabin(opts)(asAsyncIterable([])))
       throw new Error('Should have thrown')
     } catch (err: any) {
       expect(err.code).to.equal('ERR_INVALID_AVG_CHUNK_SIZE')
+    }
+  })
+
+  it('throws when invalid min chunk size is specified', async () => {
+    const opts = {
+      minChunkSize: 'fortytwo'
+    }
+
+    try {
+      // @ts-expect-error invalid input
+      await all(rabin(opts)(asAsyncIterable([])))
+      throw new Error('Should have thrown')
+    } catch (err: any) {
+      expect(err.code).to.equal('ERR_INVALID_CHUNK_SIZE')
+    }
+  })
+
+  it('throws when invalid max chunk size is specified', async () => {
+    const opts = {
+      maxChunkSize: 'fortytwo'
+    }
+
+    try {
+      // @ts-expect-error invalid input
+      await all(rabin(opts)(asAsyncIterable([])))
+      throw new Error('Should have thrown')
+    } catch (err: any) {
+      expect(err.code).to.equal('ERR_INVALID_CHUNK_SIZE')
     }
   })
 


### PR DESCRIPTION
- test(ipfs-unixfs-importer): chunker-rabin constructor empty args
- fix(chunker-rabin): types and errors are aligned

fixes #339
