### PR TITLE
feat: add a shardFanoutBits option to the importer

### DIFF
--- a/packages/ipfs-unixfs-exporter/src/resolvers/unixfs-v1/content/hamt-sharded-directory.ts
+++ b/packages/ipfs-unixfs-exporter/src/resolvers/unixfs-v1/content/hamt-sharded-directory.ts
@@ -33,7 +33,7 @@ async function * listDirectory (node: PBNode, path: string, resolve: Resolve, de
     throw errCode(err, 'ERR_NOT_UNIXFS')
   }
 
-  if (!dir.fanout) {
+  if (dir.fanout == null) {
     throw errCode(new Error('missing fanout'), 'ERR_NOT_UNIXFS')
   }
 

--- a/packages/ipfs-unixfs-exporter/src/resolvers/unixfs-v1/content/hamt-sharded-directory.ts
+++ b/packages/ipfs-unixfs-exporter/src/resolvers/unixfs-v1/content/hamt-sharded-directory.ts
@@ -1,6 +1,6 @@
-import { UnixFS } from 'ipfs-unixfs'
-import errCode from 'err-code'
 import { decode, type PBNode } from '@ipld/dag-pb'
+import errCode from 'err-code'
+import { UnixFS } from 'ipfs-unixfs'
 import map from 'it-map'
 import parallel from 'it-parallel'
 import { pipe } from 'it-pipe'

--- a/packages/ipfs-unixfs-exporter/src/utils/find-cid-in-shard.ts
+++ b/packages/ipfs-unixfs-exporter/src/utils/find-cid-in-shard.ts
@@ -68,7 +68,7 @@ const findShardCid = async (node: PBNode, name: string, blockstore: ReadableStor
     if (node.Data == null) {
       throw errCode(new Error('no data in PBNode'), 'ERR_NOT_UNIXFS')
     }
-  
+
     let dir: UnixFS
     try {
       dir = UnixFS.unmarshal(node.Data)

--- a/packages/ipfs-unixfs-exporter/src/utils/find-cid-in-shard.ts
+++ b/packages/ipfs-unixfs-exporter/src/utils/find-cid-in-shard.ts
@@ -1,7 +1,7 @@
 import { decode, type PBLink, type PBNode } from '@ipld/dag-pb'
 import { murmur3128 } from '@multiformats/murmur3'
-import { Bucket, type BucketPosition, createHAMT } from 'hamt-sharding'
 import errCode from 'err-code'
+import { Bucket, type BucketPosition, createHAMT } from 'hamt-sharding'
 import { UnixFS } from 'ipfs-unixfs'
 import type { ExporterOptions, ShardTraversalContext, ReadableStorage } from '../index.js'
 import type { CID } from 'multiformats/cid'

--- a/packages/ipfs-unixfs-exporter/test/exporter-sharded.spec.ts
+++ b/packages/ipfs-unixfs-exporter/test/exporter-sharded.spec.ts
@@ -241,7 +241,7 @@ describe('exporter sharded', function () {
     await block.put(nodeBlockCid, nodeBlockBuf)
 
     const shardNodeBuf = dagPb.encode({
-      Data: new UnixFS({ type: 'hamt-sharded-directory', fanout: 2n**8n }).marshal(),
+      Data: new UnixFS({ type: 'hamt-sharded-directory', fanout: 2n ** 8n }).marshal(),
       Links: [{
         Name: '75normal-dir',
         Tsize: nodeBlockBuf.length,

--- a/packages/ipfs-unixfs-exporter/test/exporter-sharded.spec.ts
+++ b/packages/ipfs-unixfs-exporter/test/exporter-sharded.spec.ts
@@ -4,7 +4,7 @@ import * as dagPb from '@ipld/dag-pb'
 import { expect } from 'aegir/chai'
 import { MemoryBlockstore } from 'blockstore-core'
 import { UnixFS } from 'ipfs-unixfs'
-import { importer } from 'ipfs-unixfs-importer'
+import { importer, type ImportCandidate } from 'ipfs-unixfs-importer'
 import all from 'it-all'
 import randomBytes from 'it-buffer-stream'
 import last from 'it-last'
@@ -254,5 +254,41 @@ describe('exporter sharded', function () {
     const exported = await exporter(`/ipfs/${shardNodeCid}/normal-dir/shard/file-1`, block)
 
     expect(exported.name).to.deep.equal('file-1')
+  })
+
+  it('exports a shard with a different fanout size', async () => {
+    const files: ImportCandidate[] = [{
+      path: '/baz.txt',
+      content: Uint8Array.from([0, 1, 2, 3, 4])
+    }, {
+      path: '/foo.txt',
+      content: Uint8Array.from([0, 1, 2, 3, 4])
+    }, {
+      path: '/bar.txt',
+      content: Uint8Array.from([0, 1, 2, 3, 4])
+    }]
+
+    const result = await last(importer(files, block, {
+      shardSplitThresholdBytes: 0,
+      shardFanoutBits: 4, // 2**4 = 16 children max
+      wrapWithDirectory: true
+    }))
+
+    if (result == null) {
+      throw new Error('Import failed')
+    }
+
+    const { cid } = result
+    const dir = await exporter(cid, block)
+
+    expect(dir).to.have.nested.property('unixfs.fanout', 16n)
+
+    const contents = await all(dir.content())
+
+    expect(contents.map(entry => ({
+      path: `/${entry.name}`,
+      content: entry.node
+    })))
+      .to.deep.equal(files)
   })
 })

--- a/packages/ipfs-unixfs-importer/src/dir-sharded.ts
+++ b/packages/ipfs-unixfs-importer/src/dir-sharded.ts
@@ -18,16 +18,21 @@ async function hamtHashFn (buf: Uint8Array): Promise<Uint8Array> {
 }
 
 const HAMT_HASH_CODE = BigInt(0x22)
+const DEFAULT_FANOUT_BITS = 8
+
+export interface DirShardedOptions extends PersistOptions {
+  shardFanoutBits: number
+}
 
 class DirSharded extends Dir {
   private readonly _bucket: Bucket<InProgressImportResult | Dir>
 
-  constructor (props: DirProps, options: PersistOptions) {
+  constructor (props: DirProps, options: DirShardedOptions) {
     super(props, options)
 
     this._bucket = createHAMT({
       hashFn: hamtHashFn,
-      bits: 8
+      bits: options.shardFanoutBits ?? DEFAULT_FANOUT_BITS
     })
   }
 
@@ -88,6 +93,7 @@ export default DirSharded
 
 async function * flush (bucket: Bucket<Dir | InProgressImportResult>, blockstore: Blockstore, shardRoot: DirSharded | null, options: PersistOptions): AsyncIterable<ImportResult> {
   const children = bucket._children
+  const padLength = (bucket.tableSize() - 1).toString(16).length
   const links: PBLink[] = []
   let childrenSize = 0n
 
@@ -98,7 +104,7 @@ async function * flush (bucket: Bucket<Dir | InProgressImportResult>, blockstore
       continue
     }
 
-    const labelPrefix = i.toString(16).toUpperCase().padStart(2, '0')
+    const labelPrefix = i.toString(16).toUpperCase().padStart(padLength, '0')
 
     if (child instanceof Bucket) {
       let shard
@@ -191,6 +197,7 @@ function isDir (obj: any): obj is Dir {
 
 function calculateSize (bucket: Bucket<any>, shardRoot: DirSharded | null, options: PersistOptions): number {
   const children = bucket._children
+  const padLength = (bucket.tableSize() - 1).toString(16).length
   const links: PBLink[] = []
 
   for (let i = 0; i < children.length; i++) {
@@ -200,7 +207,7 @@ function calculateSize (bucket: Bucket<any>, shardRoot: DirSharded | null, optio
       continue
     }
 
-    const labelPrefix = i.toString(16).toUpperCase().padStart(2, '0')
+    const labelPrefix = i.toString(16).toUpperCase().padStart(padLength, '0')
 
     if (child instanceof Bucket) {
       const size = calculateSize(child, null, options)

--- a/packages/ipfs-unixfs-importer/src/flat-to-shard.ts
+++ b/packages/ipfs-unixfs-importer/src/flat-to-shard.ts
@@ -1,9 +1,8 @@
 import { DirFlat } from './dir-flat.js'
-import DirSharded from './dir-sharded.js'
+import DirSharded, { type DirShardedOptions } from './dir-sharded.js'
 import type { Dir } from './dir.js'
-import type { PersistOptions } from './utils/persist.js'
 
-export async function flatToShard (child: Dir | null, dir: Dir, threshold: number, options: PersistOptions): Promise<DirSharded> {
+export async function flatToShard (child: Dir | null, dir: Dir, threshold: number, options: DirShardedOptions): Promise<DirSharded> {
   let newDir = dir as DirSharded
 
   if (dir instanceof DirFlat && dir.estimateNodeSize() > threshold) {
@@ -31,7 +30,7 @@ export async function flatToShard (child: Dir | null, dir: Dir, threshold: numbe
   return newDir
 }
 
-async function convertToShard (oldDir: DirFlat, options: PersistOptions): Promise<DirSharded> {
+async function convertToShard (oldDir: DirFlat, options: DirShardedOptions): Promise<DirSharded> {
   const newDir = new DirSharded({
     root: oldDir.root,
     dir: true,

--- a/packages/ipfs-unixfs-importer/src/index.ts
+++ b/packages/ipfs-unixfs-importer/src/index.ts
@@ -124,6 +124,13 @@ export interface ImporterOptions extends ProgressOptions<ImporterProgressEvents>
   shardSplitThresholdBytes?: number
 
   /**
+   * The number of bits of a hash digest used at each level of sharding to
+   * the child index. 2**shardFanoutBits will dictate the maximum number of
+   * children for any shard in the HAMT. Default: 8
+   */
+  shardFanoutBits?: number
+
+  /**
    * How many files to import concurrently. For large numbers of small files this
    * should be high (e.g. 50). Default: 10
    */
@@ -241,6 +248,7 @@ export async function * importer (source: ImportCandidateStream, blockstore: Wri
 
   const wrapWithDirectory = options.wrapWithDirectory ?? false
   const shardSplitThresholdBytes = options.shardSplitThresholdBytes ?? 262144
+  const shardFanoutBits = options.shardFanoutBits ?? 8
   const cidVersion = options.cidVersion ?? 1
   const rawLeaves = options.rawLeaves ?? true
   const leafType = options.leafType ?? 'file'
@@ -269,6 +277,7 @@ export async function * importer (source: ImportCandidateStream, blockstore: Wri
   const buildTree: TreeBuilder = options.treeBuilder ?? defaultTreeBuilder({
     wrapWithDirectory,
     shardSplitThresholdBytes,
+    shardFanoutBits,
     cidVersion,
     onProgress: options.onProgress
   })

--- a/packages/ipfs-unixfs-importer/src/tree-builder.ts
+++ b/packages/ipfs-unixfs-importer/src/tree-builder.ts
@@ -7,6 +7,7 @@ import type { PersistOptions } from './utils/persist.js'
 
 export interface AddToTreeOptions extends PersistOptions {
   shardSplitThresholdBytes: number
+  shardFanoutBits: number
 }
 
 async function addToTree (elem: InProgressImportResult, tree: Dir, options: AddToTreeOptions): Promise<Dir> {

--- a/packages/ipfs-unixfs/src/index.ts
+++ b/packages/ipfs-unixfs/src/index.ts
@@ -52,7 +52,8 @@ class UnixFS {
             secs: message.mtime.Seconds ?? 0n,
             nsecs: message.mtime.FractionalNanoseconds
           }
-        : undefined
+        : undefined,
+      fanout: message.fanout
     })
 
     // make sure we honour the original mode


### PR DESCRIPTION
Use the `fanout` value to slice off the correct number of characters from `Name` in HAMTs.

Fixes exporting the HAMT from https://github.com/ipld/ipld/blob/master/specs/transport/trustless-pathing/fixtures/unixfs_20m_variety.car (which has a small fanout to force collisions).

```console
$ ipfs-car ls unixfs_20m_variety.car 
.
./3l3ph4nt.txt
./5.docx
./Brabantio.docx
./Flibbertigibbet5
./Flibbertigibbet5/4.csv
./Flibbertigibbet5/5t4ck.pdf
./Flibbertigibbet5/Balderdash.json
./Flibbertigibbet5/Ballyhoo
./Flibbertigibbet5/Falstaff.pdf
./Flibbertigibbet5/Glimperwick.xml
./Flibbertigibbet5/Higgledy7.json
./Flibbertigibbet5/J.json
./Flibbertigibbet5/Lilliputian.xml
./Flibbertigibbet5/Splendiferous.png
./Flibbertigibbet5/W.png
./Flibbertigibbet5/aa.pdf
./Flibbertigibbet5/astronomicalunit.xml
./Flibbertigibbet5/by.json
./Flibbertigibbet5/chazz.png
./Flibbertigibbet5/cryptozoologician.docx
./Flibbertigibbet5/d3v3l0p3r.csv
./Flibbertigibbet5/eorþbūend
./Flibbertigibbet5/eorþhūs.xml
./Flibbertigibbet5/eorþscyld.pdf
./Flibbertigibbet5/eorþsele.xml
./Flibbertigibbet5/eorþtilþ.docx
./Flibbertigibbet5/frub.txt
./Flibbertigibbet5/hyperventilatingly.xml
./Flibbertigibbet5/jabberwocky.xml
./Flibbertigibbet5/of.png
./Flibbertigibbet5/p.png
./Flibbertigibbet5/q.pdf
./Flibbertigibbet5/r3ct4ngl3.docx
./Flibbertigibbet5/toves.txt
./Flibbertigibbet5/w0rld.json
./Flibbertigibbet5/whindle.txt
./Flibbertigibbet5/whispyfangle.csv
./Flibbertigibbet5/xu.json
./Flibbertigibbet5/y.png
./Flibbertigibbet5/zarfle.json
./Flibbertigibbet5/ďábel
./Flibbertigibbet5/ťava.txt
./Flibbertigibbet5/ǩāŕáōķê.jpg
./Flibbertigibbet5/пåŕŧy.txt
./O
./O/.xml
./O/odecahedron.xml
./O/uck.xml
./O/ụzzlę.jpg
./O/ortlewhack.jpg
./O/pontaneityvolution.docx
./O/ozyboozle.json
./O/.jpg
./O/eorn.txt
./O/bsquatulationism.json
./O/t4ck.pdf
./O/libby.txt
./O/i.pdf
./O/ëĺōđỳ.txt
./O/rocrastinatorily.png
./O/.txt
./O/lectromagnetismal.txt
./O/orþsittend.docx
./O/.pdf
./O/oliloquy.csv
./O/ocus-pocus8.png
./O/umfuzzle
./O/a.jpg
./O/nencumberedness.jpg
./O/eofwyrd
./O/cealc.json
./O/thello.png
./O/u.docx
./O/ransubstantiation.pdf
file:///Users/alan/Code/web3-storage/ipfs-car/node_modules/@ipld/dag-pb/src/pb-decode.js:155
      throw new Error(`protobuf: (PBNode) invalid wireType, expected 2, got ${wireType}`)
            ^

Error: protobuf: (PBNode) invalid wireType, expected 2, got 3
    at decodeNode (file:///Users/alan/Code/web3-storage/ipfs-car/node_modules/@ipld/dag-pb/src/pb-decode.js:155:13)
    at decode (file:///Users/alan/Code/web3-storage/ipfs-car/node_modules/@ipld/dag-pb/src/index.js:54:15)
    at file:///Users/alan/Code/web3-storage/ipfs-car/node_modules/ipfs-unixfs-exporter/dist/src/resolvers/unixfs-v1/content/hamt-sharded-directory.js:23:24
```

refs https://github.com/ipld/ipld/pull/296#issuecomment-1691532242