### PR TITLE
feat: add config option to control fanout size

### DIFF
--- a/packages/ipfs-unixfs-exporter/src/resolvers/unixfs-v1/content/hamt-sharded-directory.ts
+++ b/packages/ipfs-unixfs-exporter/src/resolvers/unixfs-v1/content/hamt-sharded-directory.ts
@@ -33,7 +33,7 @@ async function * listDirectory (node: PBNode, path: string, resolve: Resolve, de
     throw errCode(err, 'ERR_NOT_UNIXFS')
   }
 
-  if (!dir.fanout) {
+  if (dir.fanout == null) {
     throw errCode(new Error('missing fanout'), 'ERR_NOT_UNIXFS')
   }
 

--- a/packages/ipfs-unixfs-exporter/test/exporter-sharded.spec.ts
+++ b/packages/ipfs-unixfs-exporter/test/exporter-sharded.spec.ts
@@ -270,7 +270,7 @@ describe('exporter sharded', function () {
 
     const result = await last(importer(files, block, {
       shardSplitThresholdBytes: 0,
-      shardFanoutBytes: 4,
+      shardFanoutBits: 4, // 2**4 = 16 children max
       wrapWithDirectory: true
     }))
 

--- a/packages/ipfs-unixfs-importer/src/dir-sharded.ts
+++ b/packages/ipfs-unixfs-importer/src/dir-sharded.ts
@@ -18,9 +18,10 @@ async function hamtHashFn (buf: Uint8Array): Promise<Uint8Array> {
 }
 
 const HAMT_HASH_CODE = BigInt(0x22)
+const DEFAULT_FANOUT_BITS = 8
 
 export interface DirShardedOptions extends PersistOptions {
-  shardFanoutBytes: number
+  shardFanoutBits: number
 }
 
 class DirSharded extends Dir {
@@ -31,7 +32,7 @@ class DirSharded extends Dir {
 
     this._bucket = createHAMT({
       hashFn: hamtHashFn,
-      bits: options.shardFanoutBytes ?? 8
+      bits: options.shardFanoutBits ?? DEFAULT_FANOUT_BITS
     })
   }
 
@@ -196,6 +197,7 @@ function isDir (obj: any): obj is Dir {
 
 function calculateSize (bucket: Bucket<any>, shardRoot: DirSharded | null, options: PersistOptions): number {
   const children = bucket._children
+  const padLength = (bucket.tableSize() - 1).toString(16).length
   const links: PBLink[] = []
 
   for (let i = 0; i < children.length; i++) {
@@ -205,7 +207,7 @@ function calculateSize (bucket: Bucket<any>, shardRoot: DirSharded | null, optio
       continue
     }
 
-    const labelPrefix = i.toString(16).toUpperCase().padStart(2, '0')
+    const labelPrefix = i.toString(16).toUpperCase().padStart(padLength, '0')
 
     if (child instanceof Bucket) {
       const size = calculateSize(child, null, options)

--- a/packages/ipfs-unixfs-importer/src/flat-to-shard.ts
+++ b/packages/ipfs-unixfs-importer/src/flat-to-shard.ts
@@ -1,9 +1,8 @@
 import { DirFlat } from './dir-flat.js'
-import DirSharded from './dir-sharded.js'
+import DirSharded, { type DirShardedOptions } from './dir-sharded.js'
 import type { Dir } from './dir.js'
-import type { PersistOptions } from './utils/persist.js'
 
-export async function flatToShard (child: Dir | null, dir: Dir, threshold: number, options: PersistOptions): Promise<DirSharded> {
+export async function flatToShard (child: Dir | null, dir: Dir, threshold: number, options: DirShardedOptions): Promise<DirSharded> {
   let newDir = dir as DirSharded
 
   if (dir instanceof DirFlat && dir.estimateNodeSize() > threshold) {
@@ -31,7 +30,7 @@ export async function flatToShard (child: Dir | null, dir: Dir, threshold: numbe
   return newDir
 }
 
-async function convertToShard (oldDir: DirFlat, options: PersistOptions): Promise<DirSharded> {
+async function convertToShard (oldDir: DirFlat, options: DirShardedOptions): Promise<DirSharded> {
   const newDir = new DirSharded({
     root: oldDir.root,
     dir: true,

--- a/packages/ipfs-unixfs-importer/src/index.ts
+++ b/packages/ipfs-unixfs-importer/src/index.ts
@@ -124,6 +124,11 @@ export interface ImporterOptions extends ProgressOptions<ImporterProgressEvents>
   shardSplitThresholdBytes?: number
 
   /**
+   * The maximum number of bytes used as a HAMT prefix for shard entries. Default: 256
+   */
+  shardFanoutBytes?: number
+
+  /**
    * How many files to import concurrently. For large numbers of small files this
    * should be high (e.g. 50). Default: 10
    */
@@ -241,6 +246,7 @@ export async function * importer (source: ImportCandidateStream, blockstore: Wri
 
   const wrapWithDirectory = options.wrapWithDirectory ?? false
   const shardSplitThresholdBytes = options.shardSplitThresholdBytes ?? 262144
+  const shardFanoutBytes = options.shardFanoutBytes ?? 8
   const cidVersion = options.cidVersion ?? 1
   const rawLeaves = options.rawLeaves ?? true
   const leafType = options.leafType ?? 'file'
@@ -269,6 +275,7 @@ export async function * importer (source: ImportCandidateStream, blockstore: Wri
   const buildTree: TreeBuilder = options.treeBuilder ?? defaultTreeBuilder({
     wrapWithDirectory,
     shardSplitThresholdBytes,
+    shardFanoutBytes,
     cidVersion,
     onProgress: options.onProgress
   })

--- a/packages/ipfs-unixfs-importer/src/index.ts
+++ b/packages/ipfs-unixfs-importer/src/index.ts
@@ -124,9 +124,11 @@ export interface ImporterOptions extends ProgressOptions<ImporterProgressEvents>
   shardSplitThresholdBytes?: number
 
   /**
-   * The maximum number of bytes used as a HAMT prefix for shard entries. Default: 256
+   * The number of bits of a hash digest used at each level of sharding to
+   * the child index. 2**shardFanoutBits will dictate the maximum number of
+   * children for any shard in the HAMT. Default: 8
    */
-  shardFanoutBytes?: number
+  shardFanoutBits?: number
 
   /**
    * How many files to import concurrently. For large numbers of small files this
@@ -246,7 +248,7 @@ export async function * importer (source: ImportCandidateStream, blockstore: Wri
 
   const wrapWithDirectory = options.wrapWithDirectory ?? false
   const shardSplitThresholdBytes = options.shardSplitThresholdBytes ?? 262144
-  const shardFanoutBytes = options.shardFanoutBytes ?? 8
+  const shardFanoutBits = options.shardFanoutBits ?? 8
   const cidVersion = options.cidVersion ?? 1
   const rawLeaves = options.rawLeaves ?? true
   const leafType = options.leafType ?? 'file'
@@ -275,7 +277,7 @@ export async function * importer (source: ImportCandidateStream, blockstore: Wri
   const buildTree: TreeBuilder = options.treeBuilder ?? defaultTreeBuilder({
     wrapWithDirectory,
     shardSplitThresholdBytes,
-    shardFanoutBytes,
+    shardFanoutBits,
     cidVersion,
     onProgress: options.onProgress
   })

--- a/packages/ipfs-unixfs-importer/src/tree-builder.ts
+++ b/packages/ipfs-unixfs-importer/src/tree-builder.ts
@@ -7,6 +7,7 @@ import type { PersistOptions } from './utils/persist.js'
 
 export interface AddToTreeOptions extends PersistOptions {
   shardSplitThresholdBytes: number
+  shardFanoutBytes: number
 }
 
 async function addToTree (elem: InProgressImportResult, tree: Dir, options: AddToTreeOptions): Promise<Dir> {

--- a/packages/ipfs-unixfs-importer/src/tree-builder.ts
+++ b/packages/ipfs-unixfs-importer/src/tree-builder.ts
@@ -7,7 +7,7 @@ import type { PersistOptions } from './utils/persist.js'
 
 export interface AddToTreeOptions extends PersistOptions {
   shardSplitThresholdBytes: number
-  shardFanoutBytes: number
+  shardFanoutBits: number
 }
 
 async function addToTree (elem: InProgressImportResult, tree: Dir, options: AddToTreeOptions): Promise<Dir> {


### PR DESCRIPTION
Adds a `shardFanoutBytes` option to the importer to allow configuring the number of bytes used for the HAMT prefix, also a test.