### PR TITLE
fix: add cross-impl shard test, fix path cleaner

### DIFF
--- a/packages/ipfs-unixfs-importer/src/utils/to-path-components.ts
+++ b/packages/ipfs-unixfs-importer/src/utils/to-path-components.ts
@@ -1,7 +1,4 @@
 export const toPathComponents = (path: string = ''): string[] => {
   // split on / unless escaped with \
-  return (path
-    .trim()
-    .match(/([^\\/]|\\\/)+/g) ?? [])
-    .filter(Boolean)
+  return path.split(/(?<!\\)\//).filter(Boolean)
 }


### PR DESCRIPTION
Ref: https://github.com/ipfs/go-unixfsnode/pull/66

The material change in here is the path cleaner/splitter; it's a bit too aggressive. It doesn't allow `\` as a file name and the `.trim()` discounts valid file names. Otherwise this is a match for https://github.com/ipfs/go-unixfsnode/pull/66 and gets the same CID on importer, and tests the exporter can read the same data.