### PR TITLE
Enable to use defaultDagBuilder with custom fileBuilder or dirBuilder 

### DIFF
--- a/packages/ipfs-unixfs-importer/package.json
+++ b/packages/ipfs-unixfs-importer/package.json
@@ -80,7 +80,7 @@
     "hamt-sharding": "^3.0.6",
     "interface-blockstore": "^5.2.10",
     "interface-store": "^5.1.8",
-    "ipfs-unixfs": "^11.0.0",
+    "ipfs-unixfs": "^11.1.4",
     "it-all": "^3.0.4",
     "it-batch": "^3.0.4",
     "it-first": "^3.0.4",

--- a/packages/ipfs-unixfs-importer/package.json
+++ b/packages/ipfs-unixfs-importer/package.json
@@ -80,7 +80,7 @@
     "hamt-sharding": "^3.0.6",
     "interface-blockstore": "^5.2.10",
     "interface-store": "^5.1.8",
-    "ipfs-unixfs": "^11.1.4",
+    "ipfs-unixfs": "^11.0.0",
     "it-all": "^3.0.4",
     "it-batch": "^3.0.4",
     "it-first": "^3.0.4",

--- a/packages/ipfs-unixfs-importer/src/dag-builder/dir.ts
+++ b/packages/ipfs-unixfs-importer/src/dag-builder/dir.ts
@@ -1,7 +1,11 @@
 import { encode, prepare } from '@ipld/dag-pb'
 import { UnixFS } from 'ipfs-unixfs'
 import { persist } from '../utils/persist.js'
-import type { Directory, InProgressImportResult, WritableStorage } from '../index.js'
+import type {
+  Directory,
+  InProgressImportResult,
+  WritableStorage
+} from '../index.js'
 import type { Version } from 'multiformats/cid'
 
 export interface DirBuilderOptions {
@@ -9,7 +13,11 @@ export interface DirBuilderOptions {
   signal?: AbortSignal
 }
 
-export const dirBuilder = async (dir: Directory, blockstore: WritableStorage, options: DirBuilderOptions): Promise<InProgressImportResult> => {
+export const defaultDirBuilder = async (
+  dir: Directory,
+  blockstore: WritableStorage,
+  options: DirBuilderOptions
+): Promise<InProgressImportResult> => {
   const unixfs = new UnixFS({
     type: 'directory',
     mtime: dir.mtime,

--- a/packages/ipfs-unixfs-importer/src/dag-builder/dir.ts
+++ b/packages/ipfs-unixfs-importer/src/dag-builder/dir.ts
@@ -13,6 +13,14 @@ export interface DirBuilderOptions {
   signal?: AbortSignal
 }
 
+export interface DirBuilder {
+  (
+    dir: Directory,
+    blockstore: WritableStorage,
+    options: DirBuilderOptions
+  ): Promise<InProgressImportResult>
+}
+
 export const defaultDirBuilder = async (
   dir: Directory,
   blockstore: WritableStorage,

--- a/packages/ipfs-unixfs-importer/src/dag-builder/file.ts
+++ b/packages/ipfs-unixfs-importer/src/dag-builder/file.ts
@@ -232,6 +232,14 @@ const reduce = (
   return reducer
 }
 
+export interface FileBuilder {
+  (
+    file: File,
+    blockstore: WritableStorage,
+    options: FileBuilderOptions
+  ): Promise<InProgressImportResult>
+}
+
 export interface FileBuilderOptions
   extends BuildFileBatchOptions,
   ReduceOptions {

--- a/packages/ipfs-unixfs-importer/src/dag-builder/index.ts
+++ b/packages/ipfs-unixfs-importer/src/dag-builder/index.ts
@@ -1,7 +1,7 @@
 import errCode from 'err-code'
 import { CustomProgressEvent } from 'progress-events'
-import { defaultDirBuilder, type DirBuilderOptions } from './dir.js'
-import { defaultFileBuilder, type FileBuilderOptions } from './file.js'
+import { defaultDirBuilder, type DirBuilder, type DirBuilderOptions } from './dir.js'
+import { defaultFileBuilder, type FileBuilder, type FileBuilderOptions } from './file.js'
 import type { ChunkValidator } from './validate-chunks.js'
 import type { Chunker } from '../chunker/index.js'
 import type {
@@ -77,16 +77,8 @@ export interface DagBuilderOptions
   chunker: Chunker
   chunkValidator: ChunkValidator
   wrapWithDirectory: boolean
-  dirBuilder?(
-    dir: Directory,
-    blockstore: WritableStorage,
-    options: DirBuilderOptions
-  ): Promise<InProgressImportResult>
-  fileBuilder?(
-    file: File,
-    blockstore: WritableStorage,
-    options: FileBuilderOptions
-  ): Promise<InProgressImportResult>
+  dirBuilder?: DirBuilder
+  fileBuilder?: FileBuilder
 }
 
 export type ImporterSourceStream =

--- a/packages/ipfs-unixfs-importer/src/index.ts
+++ b/packages/ipfs-unixfs-importer/src/index.ts
@@ -319,6 +319,7 @@ export async function * importer (source: ImportCandidateStream, blockstore: Wri
   const fileImportConcurrency = options.fileImportConcurrency ?? 50
   const blockWriteConcurrency = options.blockWriteConcurrency ?? 10
   const reduceSingleLeafToSelf = options.reduceSingleLeafToSelf ?? true
+  
 
   const chunker = options.chunker ?? fixedSize()
   const chunkValidator = options.chunkValidator ?? defaultChunkValidator()

--- a/packages/ipfs-unixfs-importer/tsconfig.json
+++ b/packages/ipfs-unixfs-importer/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "aegir/src/config/tsconfig.aegir.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "esModuleInterop": true
   },
   "include": [
     "src",


### PR DESCRIPTION
My team and I are trying to add some additional optional metadata to directory's IPLD objects having an almost equal IPLD object as the IPFS standard. For this reason, we would want to use the `defaultDagBuilder` but customising just how file and directories IPLD objects are formed. 

For achieving this I added two additional fields to `DagBuilderOptions` & `ImporterOptions` that would override the `dirBuilder` & `fileBuilder` if that option is provided.