### PR TITLE
fix: constrain the unixfs type

### DIFF
--- a/packages/ipfs-unixfs-exporter/test/exporter.spec.ts
+++ b/packages/ipfs-unixfs-exporter/test/exporter.spec.ts
@@ -31,6 +31,7 @@ import { exporter, recursive } from '../src/index.js'
 import asAsyncIterable from './helpers/as-async-iterable.js'
 import type { PBNode } from '@ipld/dag-pb'
 import type { Blockstore } from 'interface-blockstore'
+import type { UnixFSType } from 'ipfs-unixfs'
 import type { Chunker } from 'ipfs-unixfs-importer/chunker'
 import type { FileLayout } from 'ipfs-unixfs-importer/layout'
 
@@ -46,7 +47,7 @@ describe('exporter', () => {
     smallFile = uint8ArrayConcat(await all(randomBytes(200)))
   })
 
-  async function dagPut (options: { type?: string, content?: Uint8Array, links?: dagPb.PBLink[] } = {}): Promise<{ file: UnixFS, node: PBNode, cid: CID }> {
+  async function dagPut (options: { type?: UnixFSType, content?: Uint8Array, links?: dagPb.PBLink[] } = {}): Promise<{ file: UnixFS, node: PBNode, cid: CID }> {
     options.type = options.type ?? 'file'
     options.content = options.content ?? Uint8Array.from([0x01, 0x02, 0x03])
     options.links = options.links ?? []

--- a/packages/ipfs-unixfs/README.md
+++ b/packages/ipfs-unixfs/README.md
@@ -135,7 +135,7 @@ file.mtime // undefined
 
 Object.prototype.hasOwnProperty.call(file, 'mtime') // false
 
-const dir = new UnixFS({ type: 'dir', mtime: { secs: 5n } })
+const dir = new UnixFS({ type: 'directory', mtime: { secs: 5n } })
 dir.mtime // { secs: Number, nsecs: Number }
 ```
 

--- a/packages/ipfs-unixfs/src/index.ts
+++ b/packages/ipfs-unixfs/src/index.ts
@@ -112,7 +112,7 @@
  *
  * Object.prototype.hasOwnProperty.call(file, 'mtime') // false
  *
- * const dir = new UnixFS({ type: 'dir', mtime: { secs: 5n } })
+ * const dir = new UnixFS({ type: 'directory', mtime: { secs: 5n } })
  * dir.mtime // { secs: Number, nsecs: Number }
  * ```
  */
@@ -127,7 +127,9 @@ export interface Mtime {
 
 export type MtimeLike = Mtime | { Seconds: number, FractionalNanoseconds?: number } | [number, number] | Date
 
-const types: Record<string, string> = {
+export type UnixFSType = 'raw' | 'directory' | 'file' | 'metadata' | 'symlink' | 'hamt-sharded-directory'
+
+const types: Record<string, UnixFSType> = {
   Raw: 'raw',
   Directory: 'directory',
   File: 'file',
@@ -148,7 +150,7 @@ const DEFAULT_DIRECTORY_MODE = parseInt('0755', 8)
 const MAX_FANOUT = BigInt(1 << 10)
 
 export interface UnixFSOptions {
-  type?: string
+  type?: UnixFSType
   data?: Uint8Array
   blockSizes?: bigint[]
   hashType?: bigint

--- a/packages/ipfs-unixfs/test/unixfs-format.spec.ts
+++ b/packages/ipfs-unixfs/test/unixfs-format.spec.ts
@@ -370,6 +370,7 @@ describe('unixfs-format', () => {
     try {
       // eslint-disable-next-line no-new
       new UnixFS({
+        // @ts-expect-error invalid type
         type: 'bananas'
       })
     } catch (err: any) {


### PR DESCRIPTION
Turns the unixfs type into a proper type to enable code completion and type checking.