### PR TITLE
fix: export basic file from dir or shard

### DIFF
--- a/packages/ipfs-unixfs-exporter/src/resolvers/unixfs-v1/index.ts
+++ b/packages/ipfs-unixfs-exporter/src/resolvers/unixfs-v1/index.ts
@@ -31,7 +31,7 @@ const contentExporters: Record<string, UnixfsV1Resolver> = {
 
 // @ts-expect-error types are wrong
 const unixFsResolver: Resolver = async (cid, name, path, toResolve, resolve, depth, blockstore, options) => {
-  if (isBasicExporterOptions(options)) {
+  if (isBasicExporterOptions(options) && toResolve.length === 0) {
     const basic: UnixFSBasicEntry = {
       cid,
       name,

--- a/packages/ipfs-unixfs-exporter/test/exporter.spec.ts
+++ b/packages/ipfs-unixfs-exporter/test/exporter.spec.ts
@@ -1708,4 +1708,33 @@ describe('exporter', () => {
     expect(basicDir).to.not.have.property('unixfs')
     expect(basicDir).to.not.have.property('content')
   })
+
+  it('exports basic file from directory', async () => {
+    const files: Record<string, { content: Uint8Array, cid?: CID }> = {
+      'file.txt': {
+        content: uint8ArrayConcat(await all(randomBytes(100)))
+      }
+    }
+
+    const imported = await all(importer(Object.keys(files).map(path => ({
+      path,
+      content: asAsyncIterable(files[path].content)
+    })), block, {
+      wrapWithDirectory: true,
+      rawLeaves: false
+    }))
+
+    const file = imported[0]
+    const dir = imported[imported.length - 1]
+
+    const basicfile = await exporter(`/ipfs/${dir.cid}/${file.path}`, block, {
+      extended: false
+    })
+
+    expect(basicfile).to.have.property('name', file.path)
+    expect(basicfile).to.have.property('path', `${dir.cid}/${file.path}`)
+    expect(basicfile).to.have.deep.property('cid', file.cid)
+    expect(basicfile).to.not.have.property('unixfs')
+    expect(basicfile).to.not.have.property('content')
+  })
 })


### PR DESCRIPTION
Fixes a bug whereby when exporting a deep path to a file within a directory or shard, the returned entry had the CID of the containing folder rather than the target file.