### PR TITLE
fix: include size estimate in directory listing

### DIFF
--- a/packages/ipfs-unixfs-exporter/src/exporters/dag-cbor.ts
+++ b/packages/ipfs-unixfs-exporter/src/exporters/dag-cbor.ts
@@ -13,6 +13,7 @@ export async function dagCborResolver (cid: CID, name: string, path: string, blo
     name,
     path,
     object,
-    node: block
+    node: block,
+    size: BigInt(block.byteLength)
   }
 }

--- a/packages/ipfs-unixfs-exporter/src/exporters/dag-json.ts
+++ b/packages/ipfs-unixfs-exporter/src/exporters/dag-json.ts
@@ -13,6 +13,7 @@ export async function dagJsonResolver (cid: CID, name: string, path: string, blo
     name,
     path,
     object,
-    node: block
+    node: block,
+    size: BigInt(block.byteLength)
   }
 }

--- a/packages/ipfs-unixfs-exporter/src/exporters/identity.ts
+++ b/packages/ipfs-unixfs-exporter/src/exporters/identity.ts
@@ -12,7 +12,7 @@ export async function identityResolver (cid: CID, name: string, path: string, bl
     name,
     path,
     content: rawContent(block.digest, 'unixfs:exporter:progress:identity'),
-    size: BigInt(block.bytes.length),
+    size: BigInt(block.bytes.byteLength),
     node: block.bytes
   }
 }

--- a/packages/ipfs-unixfs-exporter/src/exporters/index.ts
+++ b/packages/ipfs-unixfs-exporter/src/exporters/index.ts
@@ -110,6 +110,7 @@ export async function * recursive (path: string | CID, blockstore: ReadableStora
     cid: node.cid,
     name: node.name,
     path: node.path,
+    size: node.size,
     depth: 0
   }
 

--- a/packages/ipfs-unixfs-exporter/src/exporters/json.ts
+++ b/packages/ipfs-unixfs-exporter/src/exporters/json.ts
@@ -13,6 +13,7 @@ export async function jsonResolver (cid: CID, name: string, path: string, blocks
     name,
     path,
     object,
+    size: BigInt(block.byteLength),
     node: block
   }
 }

--- a/packages/ipfs-unixfs-exporter/src/exporters/unixfs-v1/content/directory.ts
+++ b/packages/ipfs-unixfs-exporter/src/exporters/unixfs-v1/content/directory.ts
@@ -17,7 +17,8 @@ export function directoryContent (cid: CID, node: PBNode, unixfs: UnixFS, path: 
     yield * links.map(link => ({
       cid: link.Hash,
       name: link.Name ?? '',
-      path: `${path}/${link.Name ?? ''}`
+      path: `${path}/${link.Name ?? ''}`,
+      size: BigInt(link.Tsize ?? 0)
     }))
   }
 

--- a/packages/ipfs-unixfs-exporter/src/exporters/unixfs-v1/content/hamt-sharded-directory.ts
+++ b/packages/ipfs-unixfs-exporter/src/exporters/unixfs-v1/content/hamt-sharded-directory.ts
@@ -41,7 +41,8 @@ async function * listDirectory (node: PBNode, path: string, blockstore: Readable
             entries: [{
               cid: link.Hash,
               name,
-              path: `${path}/${name}`
+              path: `${path}/${name}`,
+              size: BigInt(link.Tsize ?? 0)
             }]
           }
         } else {

--- a/packages/ipfs-unixfs-exporter/src/exporters/unixfs-v1/index.ts
+++ b/packages/ipfs-unixfs-exporter/src/exporters/unixfs-v1/index.ts
@@ -64,7 +64,8 @@ export async function dagPbResolver (cid: CID, name: string, path: string, block
       path,
       entries: content,
       unixfs,
-      node
+      node,
+      size: BigInt(block.byteLength)
     }
   }
 

--- a/packages/ipfs-unixfs-exporter/src/index.ts
+++ b/packages/ipfs-unixfs-exporter/src/index.ts
@@ -226,6 +226,12 @@ export interface UnixFSDirectoryEntry {
    * The path of the entry within the containing directory structure
    */
   path: string
+
+  /**
+   * This is the reported size of the entry - it is taken from the Tsize of the
+   * PBLink and may not be the same as the actual file size
+   */
+  size: bigint
 }
 
 export interface Exportable extends UnixFSDirectoryEntry {

--- a/packages/ipfs-unixfs-exporter/test/import-export-dir-sharding.spec.ts
+++ b/packages/ipfs-unixfs-exporter/test/import-export-dir-sharding.spec.ts
@@ -284,7 +284,8 @@ describe('builder: directory sharding', () => {
       await verifyContent({
         cid: rootHash,
         name: '',
-        path: ''
+        path: '',
+        size: 0n
       })
     })
 


### PR DESCRIPTION
Take size estimate from Tsize property for directory listings - this allows us to not load the root block for every DAG.