### PR TITLE
fix: offset/length in dirs

### DIFF
--- a/packages/ipfs-unixfs-exporter/src/exporters/unixfs-v1/content/directory.ts
+++ b/packages/ipfs-unixfs-exporter/src/exporters/unixfs-v1/content/directory.ts
@@ -8,7 +8,7 @@ export function directoryContent (cid: CID, node: PBNode, unixfs: UnixFS, path: 
   async function * yieldDirectoryContent (options: ExportContentOptions = {}): AsyncGenerator<UnixFSDirectoryEntry> {
     const offset = options.offset ?? 0
     const length = options.length ?? node.Links.length
-    const links = node.Links.slice(offset, length)
+    const links = node.Links.slice(offset, offset + length)
 
     options.onProgress?.(new CustomProgressEvent<ExportWalk>('unixfs:exporter:walk:directory', {
       cid

--- a/packages/ipfs-unixfs-exporter/src/exporters/unixfs-v1/content/hamt-sharded-directory.ts
+++ b/packages/ipfs-unixfs-exporter/src/exporters/unixfs-v1/content/hamt-sharded-directory.ts
@@ -1,73 +1,60 @@
-import { decode } from '@ipld/dag-pb'
-import { UnixFS } from 'ipfs-unixfs'
-import map from 'it-map'
-import parallel from 'it-parallel'
-import { pipe } from 'it-pipe'
+import { UnixFS, Node } from 'ipfs-unixfs'
 import toBuffer from 'it-to-buffer'
+import { CID } from 'multiformats'
 import { CustomProgressEvent } from 'progress-events'
 import { NotUnixFSError } from '../../../errors.ts'
 import type { ReadableStorage, ExportWalk, UnixFSDirectoryEntry, ExportContentOptions } from '../../../index.ts'
 import type { PBNode } from '@ipld/dag-pb'
-import type { CID } from 'multiformats'
 
-async function * listDirectory (node: PBNode, path: string, blockstore: ReadableStorage, options: ExportContentOptions): AsyncGenerator<UnixFSDirectoryEntry> {
-  const links = node.Links
+async function * listDirectory (cid: CID, path: string, blockstore: ReadableStorage, options: ExportContentOptions): AsyncGenerator<UnixFSDirectoryEntry> {
+  let index = -1
+  let yielded = 0
 
-  if (node.Data == null) {
-    throw new NotUnixFSError('no data in PBNode')
+  for await (const entry of list(cid, path, blockstore, options)) {
+    index++
+
+    if (options.offset != null && options.offset < index) {
+      continue
+    }
+
+    yield entry
+    yielded++
+
+    if (options.length != null && options.length === yielded) {
+      return
+    }
   }
+}
 
-  let dir: UnixFS
-  try {
-    dir = UnixFS.unmarshal(node.Data)
-  } catch (err: any) {
-    throw new NotUnixFSError(err.message)
-  }
+async function * list (cid: CID, path: string, blockstore: ReadableStorage, options: ExportContentOptions): AsyncGenerator<UnixFSDirectoryEntry> {
+  const block = await toBuffer(blockstore.get(cid, options))
+  const node = Node.decode(block)
 
-  if (dir.fanout == null) {
+  if (node.data?.fanOut == null) {
     throw new NotUnixFSError('missing fanout')
   }
 
-  const padLength = (dir.fanout - 1n).toString(16).length
+  const prefixLength = (node.data.fanOut - 1n).toString(16).length
 
-  const results = pipe(
-    links,
-    source => map(source, link => {
-      return async () => {
-        const name = link.Name != null ? link.Name.substring(padLength) : null
+  for (const link of node.links) {
+    if (link.name == null || link.hash == null) {
+      continue
+    }
 
-        if (name != null && name !== '') {
-          return {
-            entries: [{
-              cid: link.Hash,
-              name,
-              path: `${path}/${name}`,
-              size: BigInt(link.Tsize ?? 0)
-            }]
-          }
-        } else {
-          // descend into subshard
-          const block = await toBuffer(blockstore.get(link.Hash, options))
-          node = decode(block)
+    const cid = CID.decode(link.hash)
 
-          options.onProgress?.(new CustomProgressEvent<ExportWalk>('unixfs:exporter:walk:hamt-sharded-directory', {
-            cid: link.Hash
-          }))
+    if (link.name.length === prefixLength) {
+      yield * list(cid, path, blockstore, options)
+    } else {
+      const name = link.name.substring(prefixLength)
 
-          return {
-            entries: listDirectory(node, path, blockstore, options)
-          }
-        }
+      yield {
+        cid,
+        name: link.name.substring(prefixLength),
+        path: `${path}/${name}`,
+        size: BigInt(link.tSize ?? 0)
       }
-    }),
-    source => parallel(source, {
-      ordered: true,
-      concurrency: options.blockReadConcurrency
-    })
-  )
-
-  for await (const { entries } of results) {
-    yield * entries
+    }
   }
 }
 
@@ -77,7 +64,7 @@ export function hamtShardedDirectoryContent (cid: CID, node: PBNode, unixfs: Uni
       cid
     }))
 
-    return listDirectory(node, path, blockstore, options)
+    return listDirectory(cid, path, blockstore, options)
   }
 
   return yieldHamtDirectoryContent

--- a/packages/ipfs-unixfs-exporter/test/exporter-directories.spec.ts
+++ b/packages/ipfs-unixfs-exporter/test/exporter-directories.spec.ts
@@ -1,0 +1,61 @@
+import { expect } from 'aegir/chai'
+import { MemoryBlockstore } from 'blockstore-core'
+import { importer } from 'ipfs-unixfs-importer'
+import all from 'it-all'
+import last from 'it-last'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import { exporter } from '../src/index.ts'
+import type { Blockstore } from 'interface-blockstore'
+import type { CID } from 'multiformats/cid'
+
+describe('export - directories', () => {
+  let block: Blockstore
+
+  beforeEach(() => {
+    block = new MemoryBlockstore()
+  })
+
+  async function createDirectory (files: number): Promise<CID> {
+    const result = await last(importer([{
+      path: '/file1.txt',
+      content: uint8ArrayFromString('file 1')
+    }, {
+      path: '/file2.txt',
+      content: uint8ArrayFromString('file 2')
+    }, {
+      path: '/file3.txt',
+      content: uint8ArrayFromString('file 3')
+    }, {
+      path: '/file4.txt',
+      content: uint8ArrayFromString('file 4')
+    }, {
+      path: '/file5.txt',
+      content: uint8ArrayFromString('file 5')
+    }], block, {
+      wrapWithDirectory: true
+    }))
+
+    if (result == null) {
+      throw new Error('Import failed')
+    }
+
+    return result.cid
+  }
+
+  it('should limit directory entries', async () => {
+    const cid = await createDirectory(5)
+    const dir = await exporter(cid, block)
+
+    if (dir.type !== 'directory') {
+      throw new Error(`Unexpected type '${dir.type}'`)
+    }
+
+    const files = await all(dir.entries({
+      offset: 2,
+      length: 1
+    }))
+
+    expect(files).to.have.lengthOf(1)
+    expect(files).to.have.nested.property('[0].path', `${cid}/file3.txt`)
+  })
+})

--- a/packages/ipfs-unixfs-exporter/test/exporter-sharded.spec.ts
+++ b/packages/ipfs-unixfs-exporter/test/exporter-sharded.spec.ts
@@ -167,6 +167,23 @@ describe('exporter sharded', function () {
       }
     })
 
+    it(`should limit ${type} sharded directory entries`, async () => {
+      const dirCid = await createShard(5, options)
+      const dir = await exporter(dirCid, block)
+
+      if (dir.type !== 'directory') {
+        throw new Error(`Unexpected type '${dir.type}'`)
+      }
+
+      const files = await all(dir.entries({
+        offset: 2,
+        length: 1
+      }))
+
+      expect(files).to.have.lengthOf(1)
+      expect(files).to.have.nested.property('[0].path', `${dirCid}/file-2`)
+    })
+
     it(`exports one file from a ${type} sharded directory`, async () => {
       const dirCid = await createShard(31, options)
       const entry = await last(walkPath(`/ipfs/${dirCid}/file-14`, block))


### PR DESCRIPTION
Support offset/length in dirs. HAMTs are more complicated as the internal file order is not the same as a regular directory so entries are not sorted alphabetically, instead they are sorted by the hash prefix which is not very intuitive.

Fixes #489